### PR TITLE
Update all HB types based on HAP-NodeJS

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -174,8 +174,6 @@ function _normalizeName(id) {
       return ("Television");
     case "000000D9":
       return ("Input Source");
-    case "00000113":
-      return ("Television Speaker");
     case "000000DA":
       return ("Access Control");
     case "0000003E":

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -142,6 +142,42 @@ Service.prototype.toList = function(context) {
 
 function _normalizeName(id) {
   switch (id) {
+    case "00000111":
+      return ("Camera Control");
+    case "00000088":
+      return ("Stateful Programmable Switch");
+    case "000000A1":
+      return ("Bridge Configuration");
+    case "00000062":
+      return ("Bridging State");
+    case "00000055":
+      return ("Pairing");
+    case "000000A2":
+      return ("Protocol Information");
+    case "0000005A":
+      return ("Relay");
+    case "00000099":
+      return ("Time Information");
+    case "00000056":
+      return ("Tunneled BTLEAccessory Service");
+    case "00000129":
+      return ("Data Stream Transport Management");
+    case "00000122":
+      return ("Target Control Management");
+    case "00000125":
+      return ("Target Control");
+    case "00000127":
+      return ("Audio Stream Management");
+    case "00000133":
+      return ("Siri");
+    case "000000D8":
+      return ("Television");
+    case "000000D9":
+      return ("Input Source");
+    case "00000113":
+      return ("Television Speaker");
+    case "000000DA":
+      return ("Access Control");
     case "0000003E":
       return ("Accessory Information");
     case "000000BB":
@@ -150,6 +186,8 @@ function _normalizeName(id) {
       return ("Air Quality Sensor");
     case "00000096":
       return ("Battery Service");
+    case "00000110":
+      return ("Camera RTPStream Management");
     case "00000097":
       return ("Carbon Dioxide Sensor");
     case "0000007F":
@@ -204,6 +242,8 @@ function _normalizeName(id) {
       return ("Slat");
     case "00000087":
       return ("Smoke Sensor");
+    case "00000228":
+      return ("Smart Speaker");
     case "00000113":
       return ("Speaker");
     case "00000089":
@@ -216,17 +256,22 @@ function _normalizeName(id) {
       return ("Thermostat");
     case "000000D0":
       return ("Valve");
-    case "000000D8":
-      return ("Television");
-    case "000000D9":
-      return ("Input Source");
     case "0000008B":
       return ("Window");
     case "0000008C":
       return ("Window Covering");
-    case "00000110":
-    case "00000111":
-      return ("Camera");
+    case "0000021A":
+      return ("Camera Operating Mode");
+    case "00000204":
+      return ("Camera Event Recording Management");
+    case "0000020A":
+      return ("WiFi Router");
+    case "0000020F":
+      return ("WiFi Satellite");
+    case "00000221":
+      return ("Power Management");
+    case "00000203":
+      return ("Transfer Transport Management");
     default:
       debug("Missing HB Type", id);
   }


### PR DESCRIPTION
This PR adds all compatible types from HAP-NodeJS. For consistency, I wrote a small shell script to output this in the desired format from the raw .ts files in the NAP-NodeJS repo. It's also utilizing the official naming conventions, which are (mostly) consistent with how it was done here too.

There are only some minor effects here from your existing version:

- `Camera` has been renamed to the various `Camera` permutations
- `Speaker` has been renamed to `Television Speaker` where appropriate

So, this may introduce a small breaking change upon update, but the naming would then be consistent.

```sh
# Run the following command in ./HAP-NodeJS/src/lib/gen/
grep -h -A 2 "extends Service" * | grep -v '^--$' | grep -v 'output.write' | perl -p -e 's/\s+static (readonly )?UUID: string = //' |  perl -pe "s/^'/    case \"/" | perl -pe "s/[';]+/\":/" | perl -pe 's/export class (\w+) extends Service {\s+/      return ("\1");/' | perl -pe 's/-0000-1000-8000-0026BB765291//' | grep -v '^$' | perl -pe 's/(?<=[a-z])([A-Z])/ \1/g' | perl -pe 's/Wi Fi/WiFi/' | perl -pe 's/Fanv2/Fan v2/' | awk '{getline x;print x;}1'
```

Output is:

```js
    case "00000111":
      return ("Camera Control");
    case "00000088":
      return ("Stateful Programmable Switch");
    case "000000A1":
      return ("Bridge Configuration");
    // .. etc.
```