### PR TITLE
Support for missing camera control

### DIFF
--- a/HAP-NodeRed.js
+++ b/HAP-NodeRed.js
@@ -746,7 +746,8 @@ module.exports = function(RED) {
     if (device) {
       var message;
       switch (device.type) {
-        case "00000111": // Camera
+        case "00000110": // Camera RTPStream Management
+        case "00000111": // Camera Control
           message = {
             "resource-type": "image",
             "image-width": 1920,


### PR DESCRIPTION
I didn't realize you had this built in @NorthernMan54 !

However, what happens to this output? If I run this, for example, I can pull the snapshot as an image. Is there any way we could pass this raw data on as output? E.g., upload to GDrive, etc.

```sh
# example save snapshot
curl --request POST http://127.0.0.1:51826/resource --header "Content-Type:Application/json" --header "authorization: 031-45-154" --data '{ "aid": 115, "resource-type": "image" }'  --output "snapshot.jpg"
```