### PR TITLE
Add hb-control node output #64

### DIFF
--- a/HAP-NodeRed.html
+++ b/HAP-NodeRed.html
@@ -135,8 +135,8 @@
     oneditprepare: function() {
       var node = this;
       // console.log("foo " + node.device);
-      if (typeof node.acknoledge === 'undefined') {
-        $('#node-input-acknoledge').prop('checked', true);
+      if (typeof node.acknowledge === 'undefined') {
+        $('#node-input-acknowledge').prop('checked', true);
       }
       $('#node-input-device').change(function() {
         $('#node-input-name').val($('#node-input-device option:selected').text());
@@ -285,9 +285,9 @@
     oneditprepare: function() {
       var node = this;
       // console.log("foo " + node.device);
-      if (typeof node.acknoledge === 'undefined') {
+      if (typeof node.acknowledge === 'undefined') {
         // console.log("ben");
-        $('#node-input-acknoledge').prop('checked', true);
+        $('#node-input-acknowledge').prop('checked', true);
       }
       $('#node-input-device').change(function() {
         $('#node-input-name').val($('#node-input-device option:selected').text());
@@ -435,9 +435,9 @@
     oneditprepare: function() {
       var node = this;
       // console.log("foo " + node.device);
-      if (typeof node.acknoledge === 'undefined') {
+      if (typeof node.acknowledge === 'undefined') {
         // console.log("ben");
-        $('#node-input-acknoledge').prop('checked', true);
+        $('#node-input-acknowledge').prop('checked', true);
       }
       $('#node-input-device').change(function() {
         $('#node-input-name').val($('#node-input-device option:selected').text());
@@ -588,9 +588,9 @@
     oneditprepare: function() {
       var node = this;
       // console.log("foo " + node.device);
-      if (typeof node.acknoledge === 'undefined') {
+      if (typeof node.acknowledge === 'undefined') {
         // console.log("ben");
-        $('#node-input-acknoledge').prop('checked', true);
+        $('#node-input-acknowledge').prop('checked', true);
       }
       $('#node-input-device').change(function() {
         $('#node-input-name').val($('#node-input-device option:selected').text());

--- a/HAP-NodeRed.js
+++ b/HAP-NodeRed.js
@@ -484,7 +484,7 @@ module.exports = function(RED) {
           node.send(msg);
         }
       });
-    });
+    });    
 
     node.on('close', function(callback) {
       callback();
@@ -873,7 +873,7 @@ module.exports = function(RED) {
                     node.timeout = setTimeout(function() {
                       node.status({});
                     }, 10 * 1000);
-                    callback(null);
+                    callback(null, payload);
                   } else if (!err) {
                     debug("Controlled %s ->", device.id, payload);
                     node.status({
@@ -885,7 +885,7 @@ module.exports = function(RED) {
                     node.timeout = setTimeout(function() {
                       node.status({});
                     }, 10 * 1000);
-                    callback(null);
+                    callback(null, payload);
                   } else {
                     node.error(device.id + " -> " + err + " -> " + status);
                     node.status({


### PR DESCRIPTION
Addresses issue #64

This pull request consists of two commits:
1. A superficial typo fix changing all instances of `acknoledge` to `acknowledge`.
2. Adds `payload` as an argument for the `data` parameter for the callbacks in successful branches of the `_control` function's control flow.

Resulting behavior is that a `msg` with the `payload` passed by the `hb-control` node to whatever Homebridge device also gets returned when the `payload` is passed successfully based on matching characteristics, and no `msg` or `payload` get returned when the `payload` is not passed successfully. The returned `msg` can be passed to other nodes via the node-red flow if the `Outputs` property of the `hb-control` node is > 0.

Tested on clean local instances of homebridge and node-red, linking the clone of the `node-red-contrib-homebridge-automation` repo, making the changes locally and testing accordingly. Also feel free to take a look at the screenshot below.

![image](https://user-images.githubusercontent.com/6090113/100876702-936d9500-345c-11eb-8924-92eb07728f53.png)