### PR TITLE
add common supported types Window, Window Covering, Light Sensor

### DIFF
--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -81,6 +81,7 @@ class HBConfigNode {
       'Leak Sensor', 'Lightbulb', 'Lock Mechanism', 'Motion Sensor', 'Occupancy Sensor',
       'Outlet', 'Smoke Sensor', 'Speaker', 'Stateless Programmable Switch', 'Switch',
       'Television', 'Temperature Sensor', 'Thermostat', 'Contact Sensor',
+      'Window', 'Window Covering', 'Light Sensor'
     ]);
     return filterUnique(this.hbDevices)
       .filter(service => supportedTypes.has(service.humanType))


### PR DESCRIPTION
## :recycle: Current situation

Window covering and light sensor devices not showing up.




## :bulb: Proposed solution

I have added most common ones I need to the HBConfigNode constructor: 

Window
Window Covering
Light Sensor

All seem to work fine.



## :gear: Release Notes

...

## :heavy_plus_sign: Additional Information

...

### Testing

None - am just getting into this stuff. Works on my setup.

### Reviewer Nudging

Just the one line ;-)
