### PR TITLE
add support to Air Purifier device type

### DIFF
--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -76,7 +76,7 @@ class HBConfigNode {
 
   toList(perms) {
     const supportedTypes = new Set([
-      'Battery', 'Carbon Dioxide Sensor', 'Carbon Monoxide Sensor', 'Camera Rtp Stream Management',
+      'Air Purifier', 'Battery', 'Carbon Dioxide Sensor', 'Carbon Monoxide Sensor', 'Camera Rtp Stream Management',
       'Doorbell', 'Fan', 'Fanv2', 'Garage Door Opener', 'Humidity Sensor', 'Input Source',
       'Leak Sensor', 'Lightbulb', 'Lock Mechanism', 'Motion Sensor', 'Occupancy Sensor',
       'Outlet', 'Smoke Sensor', 'Speaker', 'Stateless Programmable Switch', 'Switch',


### PR DESCRIPTION
- add support to 'Air Purifier' device type
- tested with 2 air purifiers of different manufacturers 