### PR TITLE
add support to light sensor device type

### DIFF
--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -78,7 +78,7 @@ class HBConfigNode {
     const supportedTypes = new Set([
       'Air Purifier', 'Air Quality Sensor', 'Battery', 'Carbon Dioxide Sensor', 'Carbon Monoxide Sensor', 'Camera Rtp Stream Management',
       'Doorbell', 'Fan', 'Fanv2', 'Garage Door Opener', 'Humidity Sensor', 'Input Source',
-      'Leak Sensor', 'Lightbulb', 'Lock Mechanism', 'Motion Sensor', 'Occupancy Sensor',
+      'Leak Sensor', 'Light Sensor', 'Lightbulb', 'Lock Mechanism', 'Motion Sensor', 'Occupancy Sensor',
       'Outlet', 'Smoke Sensor', 'Speaker', 'Stateless Programmable Switch', 'Switch',
       'Television', 'Temperature Sensor', 'Thermostat', 'Contact Sensor',
     ]);


### PR DESCRIPTION
add support for  light sensor device. Tested with IKEA VALLHORN