### PR TITLE
Fix deploy reconnection, message queuing, and editor UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1583,6 +1583,16 @@
         "moment-timezone": "0.5.48"
       }
     },
+    "node_modules/@node-red/util/node_modules/jsonata": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
+      "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@node-rs/bcrypt": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-1.10.7.tgz",
@@ -2606,16 +2616,6 @@
         "@types/node-red__registry": "*",
         "@types/node-red__runtime": "*",
         "jsonata": "2.0.5"
-      }
-    },
-    "node_modules/@types/node-red__util/node_modules/jsonata": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
-      "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@types/passport": {
@@ -3929,9 +3929,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {
@@ -6862,6 +6862,17 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
@@ -7124,9 +7135,9 @@
       }
     },
     "node_modules/jsonata": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
-      "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
+      "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9355,17 +9366,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/split2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@homebridge/hap-client": "^3.1.1",
-        "better-queue": ">=3.8.12",
         "debug": "^4.4.1"
       },
       "devDependencies": {
@@ -60,7 +59,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1952,7 +1950,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2165,23 +2162,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/better-queue": {
-      "version": "3.8.12",
-      "license": "MIT",
-      "dependencies": {
-        "better-queue-memory": "^1.0.1",
-        "node-eta": "^0.9.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/better-queue/node_modules/better-queue-memory": {
-      "version": "1.0.4",
-      "license": "MIT"
-    },
-    "node_modules/better-queue/node_modules/node-eta": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2225,7 +2205,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2847,7 +2826,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4790,7 +4768,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5927,7 +5904,6 @@
       "version": "13.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "should-equal": "^2.0.0",
         "should-format": "^3.0.3",
@@ -10022,6 +9998,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@homebridge/hap-client": "^3.1.1",
-    "better-queue": ">=3.8.12",
     "debug": "^4.4.1"
   },
   "author": "NorthernMan54",

--- a/src/HAP-NodeRed.html
+++ b/src/HAP-NodeRed.html
@@ -62,28 +62,92 @@
     color: '#F3B567',
     label: function() {
       return this.username;
-    },
-    oneditsave: function() {
-      // var node = this;
-      // var user = $('#node-config-input-PIN').val();
-      // var pass = $('#node-config-input-password').val();
-      // console.log("pass: ", pass);
-      // if (pass != '_PWD_') {
-      //  var configNode = {
-      //    id: node.id,
-      //    user: user,
-      //    pass: pass
-      //  }
-      // $.ajax({
-      //  data: JSON.stringify(configNode),
-      //  url: 'alexa-home/new-configNode',
-      //  contentType: 'application/json',
-      //  type: 'POST',
-      //  processData: false
-      // });
-      // }
     }
   });
+</script>
+
+<script type="text/javascript">
+  // Shared editor functions for all Homebridge node types
+  function hbPopulateDevices(node, deviceKey) {
+    return function(configNode) {
+      $.getJSON('hap-device/' + deviceKey + '/' + configNode, function(data) {
+        $('#node-input-device').find('option').remove().end();
+        data.forEach(function(d) {
+          $('<option/>', {
+            value: d.uniqueId,
+            name: d.name,
+            text: d.fullName,
+            homebridge: d.homebridge,
+            manufacturer: d.manufacturer,
+            service: d.service
+          }).appendTo('#node-input-device');
+        });
+        if (node.device) {
+          $('#node-input-device').val(node.device);
+        }
+      }).fail(function() {
+        console.log('[hb-config] problem getting ' + deviceKey);
+      });
+    };
+  }
+
+  function hbOnEditPrepare(node, deviceKey) {
+    var getDevs = hbPopulateDevices(node, deviceKey);
+
+    $('#node-input-device').change(function() {
+      $('#node-input-name').val($('#node-input-device option:selected').text());
+    });
+
+    if (node.conf) {
+      var configNode = $('#node-input-conf').val();
+      if (configNode != '_ADD_') {
+        getDevs(configNode);
+      }
+    }
+
+    $('#node-input-conf').change(function() {
+      var configNode = $('#node-input-conf').val();
+      if (configNode != '_ADD_') {
+        getDevs(configNode);
+      } else {
+        $('#node-input-device').find('option').remove().end();
+        $('#node-input-device').val('');
+      }
+    });
+
+    $('#node-input-device-refresh').click(function() {
+      var $btn = $('#node-input-device-refresh');
+      if ($btn.hasClass('disabled')) return;
+      $btn.addClass('disabled');
+      $btn.find('i').addClass('fa-spin');
+      var configNode = $('#node-input-conf').val();
+      $.ajax({
+        url: 'hap-device/refresh/' + configNode,
+        type: 'POST'
+      }).done(function() {
+        getDevs(configNode);
+      }).fail(function(jqXHR) {
+        if (jqXHR.status === 404) {
+          RED.notify('Please deploy first before refreshing devices.', 'warning');
+        } else {
+          RED.notify('Error refreshing devices.', 'error');
+        }
+      }).always(function() {
+        $btn.removeClass('disabled');
+        $btn.find('i').removeClass('fa-spin');
+      });
+    });
+  }
+
+  function hbOnEditSave() {
+    var selected = $('#node-input-device option:selected');
+    if (!selected.length) return;
+    this.name = (selected.attr('name') || '').toString();
+    this.Homebridge = (selected.attr('homebridge') || '').toString();
+    this.Manufacturer = (selected.attr('manufacturer') || '').toString();
+    this.Service = (selected.attr('service') || '').toString();
+    $('#node-input-name').val(this.name);
+  }
 </script>
 
 <script type="text/x-red" data-template-name="hb-event">
@@ -129,8 +193,6 @@
       <dd>Accessory service type</dd>
       <dt>_device<span class="property-type">string</span></dt>
       <dd>Internal device identifier</dd>
-      <dt>_rawEvent<span class="property-type">string</span></dt>
-      <dd>Event as received from homebridge</dd>
   </dl>
 <h3>Details</h3>
 <p>Each Homebridge Event node, will emit a message containing the updated status of the service that has changed.</p>
@@ -170,79 +232,9 @@
     label: function() {
       return this.name || "Choose accessory/service";
     },
-    oneditsave: function() {
-      var n = $('#node-input-device option:selected').text();
-      // console.log("selected name ", $('#node-input-device option:selected'));
-
-      this.name = $('#node-input-device option:selected').attr('name').toString();
-      // this.fullName = $('#node-input-device option:selected').attr('text').toString();
-      this.Homebridge = $('#node-input-device option:selected').attr('homebridge').toString();
-      this.Manufacturer = $('#node-input-device option:selected').attr('manufacturer').toString();
-      this.Service = $('#node-input-device option:selected').attr('service').toString();
-      $('#node-input-name').val(this.name);
-    },
+    oneditsave: hbOnEditSave,
     oneditprepare: function() {
-      var node = this;
-      // console.log("foo " + node.device);
-      if (typeof node.acknowledge === 'undefined') {
-        $('#node-input-acknowledge').prop('checked', true);
-      }
-      $('#node-input-device').change(function() {
-        $('#node-input-name').val($('#node-input-device option:selected').text());
-      });
-      var getDevs = function(configNode) {
-        $.getJSON('hap-device/evDevices/' + configNode, function(data) {
-          $('#node-input-device').find('option').remove().end();
-          for (d in data) {
-            $('<option/>', {
-              value: data[d].uniqueId,
-              name: data[d].name,
-              text: data[d].fullName,
-              homebridge: data[d].homebridge,
-              manufacturer: data[d].manufacturer,
-              service: data[d].service
-            }).appendTo('#node-input-device');
-          }
-          if (node.device) {
-            $('#node-input-device').val(node.device);
-          }
-        }).fail(function(jqXHR, textStatus, errorThrown) {
-          console.log("[hb-config] problem getting evDevices");
-          console.log(textStatus);
-        });
-
-      }
-      if (node.conf) {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        }
-      }
-      $('#node-input-conf').change(function() {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode changed: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        } else {
-          // console.log("new configNode");
-          $('#node-input-device').find('option').remove().end();
-          $('#node-input-device').val("");
-        }
-      });
-      $('#node-input-device-refresh').click(function() {
-        $('#node-input-device-refresh').addClass('disabled');
-        var configNode = $('#node-input-conf').val();
-        $.ajax({
-          url: 'hap-device/refresh/' + configNode,
-          type: 'POST'
-        }).done(function(data) {
-          setTimeout(function() {
-            getDevs(configNode);
-            $('#node-input-device-refresh').removeClass('disabled');
-          }, 3000);
-        });
-      });
+      hbOnEditPrepare(this, 'evDevices');
     }
   });
 </script>
@@ -261,7 +253,6 @@
 	</div>
 
     <input type="hidden" id="node-input-name">
-    </div>
 </script>
 
 
@@ -284,8 +275,6 @@
       <dd>Accessory service type</dd>
       <dt>_device<span class="property-type">string</span></dt>
       <dd>Internal device identifier</dd>
-      <dt>_rawEvent<span class="property-type">string</span></dt>
-      <dd>Event as received from homebridge</dd>
   </dl>
 <h3>Where and why would you use this node?</h3>
 <p>I'm using this with a group of lights in a room, where I have either an automation to turn on all the lights for a short period of time ( ie arrive home turning on the lights around the door) or an Amazon Alexa.  And what it does is restore all the lights in the group to the state they where in, prior to being turned on.  So if you have a light on in a room, and you ask Alexa to turn on all the lights, then a few minutes later you can then ask her to turn them off, she will turn them all off except the one that was on previously.  If you ask her to turn off all the lights a second time, she will then turn them all off.</p>
@@ -321,85 +310,12 @@
     label: function() {
       return this.name || "Choose accessory/service";
     },
-    oneditsave: function() {
-      var n = $('#node-input-device option:selected').text();
-      // console.log("selected name ", $('#node-input-device option:selected'));
-
-      this.sname = $('#node-input-device option:selected').attr('name').toString();
-      this.Homebridge = $('#node-input-device option:selected').attr('homebridge').toString();
-      this.Manufacturer = $('#node-input-device option:selected').attr('manufacturer').toString();
-      this.Service = $('#node-input-device option:selected').attr('service').toString();
-      $('#node-input-name').val(this.sname);
-    },
+    oneditsave: hbOnEditSave,
     oneditprepare: function() {
-      var node = this;
-      // console.log("foo " + node.device);
-      if (typeof node.acknowledge === 'undefined') {
-        // console.log("ben");
-        $('#node-input-acknowledge').prop('checked', true);
-      }
-      $('#node-input-device').change(function() {
-        $('#node-input-name').val($('#node-input-device option:selected').text());
-      });
-      var getDevs = function(configNode) {
-        $.getJSON('hap-device/evDevices/' + configNode, function(data) {
-          $('#node-input-device').find('option').remove().end();
-          for (d in data) {
-            $('<option/>', {
-              value: data[d].uniqueId,
-              fullName: data[d].fullName,
-              name: data[d].name,
-              text: data[d].fullName,
-              homebridge: data[d].homebridge,
-              manufacturer: data[d].manufacturer,
-              service: data[d].service
-            }).appendTo('#node-input-device');
-          }
-          if (node.device) {
-            $('#node-input-device').val(node.device);
-          }
-        }).fail(function(jqXHR, textStatus, errorThrown) {
-          console.log("[hb-config] problem getting evDevices");
-          console.log(textStatus);
-        });
-
-      }
-      if (node.conf) {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        }
-      }
-      $('#node-input-conf').change(function() {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode changed: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        } else {
-          // console.log("new configNode");
-          $('#node-input-device').find('option').remove().end();
-          $('#node-input-device').val("");
-        }
-      });
-      $('#node-input-device-refresh').click(function() {
-        $('#node-input-device-refresh').addClass('disabled');
-        var configNode = $('#node-input-conf').val();
-        $.ajax({
-          url: 'hap-device/refresh/' + configNode,
-          type: 'POST'
-        }).done(function(data) {
-          setTimeout(function() {
-            getDevs(configNode);
-            $('#node-input-device-refresh').removeClass('disabled');
-          }, 3000);
-        });
-      });
+      hbOnEditPrepare(this, 'evDevices');
     }
   });
 </script>
-
-// Start of HAP Status
 
 <script type="text/x-red" data-template-name="hb-status">
   <div class="form-row">
@@ -415,7 +331,6 @@
 	</div>
 
     <input type="hidden" id="node-input-name">
-    </div>
 </script>
 
 
@@ -472,84 +387,12 @@
     label: function() {
       return this.name || "Choose accessory/service";
     },
-    oneditsave: function() {
-      var n = $('#node-input-device option:selected').text();
-      // console.log("selected name " + n);
-      this.sname = $('#node-input-device option:selected').attr('name').toString();
-      this.Homebridge = $('#node-input-device option:selected').attr('homebridge').toString();
-      this.Manufacturer = $('#node-input-device option:selected').attr('manufacturer').toString();
-      this.Service = $('#node-input-device option:selected').attr('service').toString();
-      $('#node-input-name').val(this.sname);
-    },
+    oneditsave: hbOnEditSave,
     oneditprepare: function() {
-      var node = this;
-      // console.log("foo " + node.device);
-      if (typeof node.acknowledge === 'undefined') {
-        // console.log("ben");
-        $('#node-input-acknowledge').prop('checked', true);
-      }
-      $('#node-input-device').change(function() {
-        $('#node-input-name').val($('#node-input-device option:selected').text());
-      });
-      var getDevs = function(configNode) {
-        $.getJSON('hap-device/evDevices/' + configNode, function(data) {
-          $('#node-input-device').find('option').remove().end();
-          for (d in data) {
-            $('<option/>', {
-              value: data[d].uniqueId,
-              fullName: data[d].fullName,
-              name: data[d].name,
-              text: data[d].fullName,
-              homebridge: data[d].homebridge,
-              manufacturer: data[d].manufacturer,
-              service: data[d].service
-            }).appendTo('#node-input-device');
-          }
-          if (node.device) {
-            $('#node-input-device').val(node.device);
-          }
-        }).fail(function(jqXHR, textStatus, errorThrown) {
-          console.log("[hb-config] problem getting ctDevices");
-          console.log(textStatus);
-        });
-
-      }
-      if (node.conf) {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        }
-      }
-      $('#node-input-conf').change(function() {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode changed: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        } else {
-          // console.log("new configNode");
-          $('#node-input-device').find('option').remove().end();
-          $('#node-input-device').val("");
-        }
-      });
-      $('#node-input-device-refresh').click(function() {
-        $('#node-input-device-refresh').addClass('disabled');
-        var configNode = $('#node-input-conf').val();
-        $.ajax({
-          url: 'hap-device/refresh/' + configNode,
-          type: 'POST'
-        }).done(function(data) {
-          setTimeout(function() {
-            getDevs(configNode);
-            $('#node-input-device-refresh').removeClass('disabled');
-          }, 3000);
-        });
-      });
+      hbOnEditPrepare(this, 'evDevices');
     }
   });
 </script>
-
-// Start of HAP Control
 
 <script type="text/x-red" data-template-name="hb-control">
   <div class="form-row">
@@ -570,7 +413,6 @@
    </div>
 
     <input type="hidden" id="node-input-name">
-    </div>
 
 </script>
 
@@ -625,79 +467,9 @@
     label: function() {
       return this.name || "Choose accessory/service";
     },
-    oneditsave: function() {
-      var n = $('#node-input-device option:selected').text();
-      // console.log("selected name " + n);
-      this.name = $('#node-input-device option:selected').attr('name').toString();
-      this.Homebridge = $('#node-input-device option:selected').attr('homebridge').toString();
-      this.Manufacturer = $('#node-input-device option:selected').attr('manufacturer').toString();
-      this.Service = $('#node-input-device option:selected').attr('service').toString();
-      $('#node-input-name').val(this.name);
-    },
+    oneditsave: hbOnEditSave,
     oneditprepare: function() {
-      var node = this;
-      // console.log("foo " + node.device);
-      if (typeof node.acknowledge === 'undefined') {
-        // console.log("ben");
-        $('#node-input-acknowledge').prop('checked', true);
-      }
-      $('#node-input-device').change(function() {
-        $('#node-input-name').val($('#node-input-device option:selected').text());
-      });
-      var getDevs = function(configNode) {
-        $.getJSON('hap-device/ctDevices/' + configNode, function(data) {
-          $('#node-input-device').find('option').remove().end();
-          for (d in data) {
-            $('<option/>', {
-              value: data[d].uniqueId,
-              fullName: data[d].fullName,
-              name: data[d].name,
-              text: data[d].fullName,
-              homebridge: data[d].homebridge,
-              manufacturer: data[d].manufacturer,
-              service: data[d].service
-            }).appendTo('#node-input-device');
-          }
-          if (node.device) {
-            $('#node-input-device').val(node.device);
-          }
-        }).fail(function(jqXHR, textStatus, errorThrown) {
-          console.log("[hb-config] problem getting ctDevices");
-          console.log(textStatus);
-        });
-
-      }
-      if (node.conf) {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        }
-      }
-      $('#node-input-conf').change(function() {
-        var configNode = $('#node-input-conf').val();
-        // console.log("configNode changed: ", configNode);
-        if (configNode != '_ADD_') {
-          getDevs(configNode);
-        } else {
-          // console.log("new configNode");
-          $('#node-input-device').find('option').remove().end();
-          $('#node-input-device').val("");
-        }
-      });
-      $('#node-input-device-refresh').click(function() {
-        $('#node-input-device-refresh').addClass('disabled');
-        var configNode = $('#node-input-conf').val();
-        $.ajax({
-          url: 'hap-device/refresh/' + configNode,
-          type: 'POST'
-        }).done(function(data) {
-          setTimeout(function() {
-            getDevs(configNode);
-            $('#node-input-device-refresh').removeClass('disabled');
-          }, 3000);
-        });
-      });
+      hbOnEditPrepare(this, 'ctDevices');
     }
   });
 </script>

--- a/src/HAP-NodeRed.js
+++ b/src/HAP-NodeRed.js
@@ -9,7 +9,6 @@ const HbStatusNode = require('./hbStatusNode');
 const HapDeviceRoutes = require('./HapDeviceRoutes');
 
 module.exports = function (RED) {
-  var hbDevices;
 
   class hbConfigNode extends HBConfigNode {
     constructor(config) {
@@ -58,7 +57,7 @@ module.exports = function (RED) {
 
   RED.nodes.registerType("hb-status", hbStatusNode);
 
-  const hapDeviceRoutes = new HapDeviceRoutes(RED, hbDevices);
+  const hapDeviceRoutes = new HapDeviceRoutes(RED);
   hapDeviceRoutes.registerRoutes();
 
 };

--- a/src/HapDeviceRoutes.js
+++ b/src/HapDeviceRoutes.js
@@ -6,23 +6,19 @@ class HapDeviceRoutes {
   }
 
   // POST /hap-device/refresh/:id
-  refreshDevice(req, res) {
+  async refreshDevice(req, res) {
     const conf = this.RED.nodes.getNode(req.params.id);
     if (conf) {
-      res.status(200).send();
+      try {
+        await conf.refreshDeviceList();
+        res.status(200).send();
+      } catch (e) {
+        debug('Error refreshing devices: %s', e.message);
+        res.status(500).send({ error: e.message });
+      }
     } else {
       debug("Can't refresh until deployed");
       res.status(404).send();
-    }
-  }
-
-  // GET /hap-device/evDevices/
-  getDevices(req, res, perms) {
-    const devices = this.RED.nodes.getNode(req.params.id)?.evDevices;
-    if (devices && devices.length) {
-      res.send(devices);
-    } else {
-      res.status(404).send({ error: `No devices found for perms: ${perms}` });
     }
   }
 
@@ -37,22 +33,14 @@ class HapDeviceRoutes {
     }
   }
 
-  // Register all routes
+  // Register all routes — use hb-conf.read since all routes operate on
+  // config node data and every homebridge node requires the config node
   registerRoutes() {
-    const routes = [
-      { method: 'post', path: '/hap-device/refresh/:id', permission: 'hb-event.read', handler: this.refreshDevice },
-      { method: 'get', path: '/hap-device/evDevices/', permission: 'hb-event.read', handler: (req, res) => this.getDevices(req, res, 'ev') },
-      { method: 'get', path: '/hap-device/evDevices/:id', permission: 'hb-event.read', handler: (req, res) => this.getDeviceById(req, res, 'evDevices') },
-      { method: 'post', path: '/hap-device/refresh/:id', permission: 'hb-resume.read', handler: this.refreshDevice },
-      { method: 'get', path: '/hap-device/evDevices/', permission: 'hb-resume.read', handler: (req, res) => this.getDevices(req, res, 'ev') },
-      { method: 'get', path: '/hap-device/evDevices/:id', permission: 'hb-resume.read', handler: (req, res) => this.getDeviceById(req, res, 'evDevices') },
-      { method: 'get', path: '/hap-device/ctDevices/', permission: 'hb-control.read', handler: (req, res) => this.getDevices(req, res, 'pw') },
-      { method: 'get', path: '/hap-device/ctDevices/:id', permission: 'hb-control.read', handler: (req, res) => this.getDeviceById(req, res, 'ctDevices') },
-    ];
+    const auth = this.RED.auth.needsPermission('hb-conf.read');
 
-    routes.forEach(({ method, path, permission, handler }) => {
-      this.RED.httpAdmin[method](path, this.RED.auth.needsPermission(permission), handler.bind(this));
-    });
+    this.RED.httpAdmin.post('/hap-device/refresh/:id', auth, this.refreshDevice.bind(this));
+    this.RED.httpAdmin.get('/hap-device/evDevices/:id', auth, (req, res) => this.getDeviceById(req, res, 'evDevices'));
+    this.RED.httpAdmin.get('/hap-device/ctDevices/:id', auth, (req, res) => this.getDeviceById(req, res, 'ctDevices'));
   }
 }
 

--- a/src/hbBaseNode.js
+++ b/src/hbBaseNode.js
@@ -1,5 +1,7 @@
 const debug = require('debug')('hapNodeRed:hbBaseNode');
 
+const PENDING_MESSAGE_TIMEOUT = 30000; // 30 seconds
+
 class HbBaseNode {
   constructor(config, RED) {
     debug("Constructor:", config.type, JSON.stringify(config));
@@ -17,19 +19,66 @@ class HbBaseNode {
     this.name = config.name;
     this.fullName = `${config.name} - ${config.Service}`;
     this.hbDevice = null;
+    this._pendingMessages = [];
 
     this.hbConfigNode?.registerClientNode(this);
 
     if (this.handleInput) {
-      this.on('input', this.handleInput.bind(this));
+      this.on('input', this._onInput.bind(this));
     }
-    if (this.handleHbReady) {
-      this.on('hbReady', this.handleHbReady.bind(this))
-    }
-    this.on('close', this.handleClose.bind(this));
+    this.on('hbReady', (service) => {
+      if (this.handleHbReady) {
+        this.handleHbReady(service);
+      }
+      this._drainPendingMessages();
+    });
+    this.on('close', this._onClose.bind(this));
     if (this.handleHBEventMessage) {
       this.on('hbEvent', this.handleHBEventMessage.bind(this));
     }
+  }
+
+  _onInput(message, send, done) {
+    if (!this.hbDevice) {
+      this._queueMessage(message, send, done);
+    } else {
+      this.handleInput(message, send, done);
+    }
+  }
+
+  _queueMessage(message, send, done) {
+    const timer = setTimeout(() => {
+      this._pendingMessages = this._pendingMessages.filter(m => m.timer !== timer);
+      this.handleWarning('HB not initialized (timeout)');
+      if (done) done('HB not initialized');
+    }, PENDING_MESSAGE_TIMEOUT);
+    this._pendingMessages.push({ message, send, done, timer });
+    debug('Queued message for %s (%d pending)', this.name, this._pendingMessages.length);
+    this.status({ fill: 'yellow', shape: 'ring', text: `queued (${this._pendingMessages.length})` });
+  }
+
+  async _drainPendingMessages() {
+    if (!this._pendingMessages.length) return;
+    debug('Draining %d pending messages for %s', this._pendingMessages.length, this.name);
+    const pending = this._pendingMessages.splice(0);
+    for (const { message, send, done, timer } of pending) {
+      clearTimeout(timer);
+      try {
+        await this.handleInput(message, send, done);
+      } catch (err) {
+        debug('Error processing queued message for %s: %s', this.name, err.message);
+        if (done) done(err.message);
+      }
+    }
+  }
+
+  _onClose(removed, done) {
+    this._pendingMessages.forEach(({ timer }) => clearTimeout(timer));
+    this._pendingMessages = [];
+    if (this.hbConfigNode) {
+      this.hbConfigNode.unregisterClientNode(this);
+    }
+    this.handleClose(removed, done);
   }
 
   createMessage(service) {

--- a/src/hbBaseNode.js
+++ b/src/hbBaseNode.js
@@ -20,6 +20,7 @@ class HbBaseNode {
     this.name = config.name;
     this.fullName = `${config.name} - ${config.Service}`;
     this.hbDevice = null;
+    this._disconnected = false;
     this._pendingMessages = [];
 
     this.hbConfigNode?.registerClientNode(this);
@@ -28,10 +29,17 @@ class HbBaseNode {
       this.on('input', this._onInput.bind(this));
     }
     this.on('hbReady', (service) => {
+      this._disconnected = false;
       if (this.handleHbReady) {
         this.handleHbReady(service);
       }
       this._drainPendingMessages();
+    });
+    this.on('hbDisconnected', () => {
+      this._disconnected = true;
+      if (this.handleHbDisconnected) {
+        this.handleHbDisconnected();
+      }
     });
     this.on('close', this._onClose.bind(this));
     if (this.handleHBEventMessage) {
@@ -40,7 +48,7 @@ class HbBaseNode {
   }
 
   _onInput(message, send, done) {
-    if (!this.hbDevice) {
+    if (!this.hbDevice || this._disconnected) {
       this._queueMessage(message, send, done);
     } else {
       this.handleInput(message, send, done);
@@ -48,14 +56,15 @@ class HbBaseNode {
   }
 
   _queueMessage(message, send, done) {
+    const reason = this._disconnected ? 'disconnected' : 'pending';
     const timer = setTimeout(() => {
       this._pendingMessages = this._pendingMessages.filter(m => m.timer !== timer);
       this.handleWarning('HB not initialized (timeout)');
       if (done) done('HB not initialized');
     }, PENDING_MESSAGE_TIMEOUT);
     this._pendingMessages.push({ message, send, done, timer });
-    debug('Queued message for %s (%d pending)', this.name, this._pendingMessages.length);
-    this.status({ fill: 'yellow', shape: 'ring', text: `queued (${this._pendingMessages.length})` });
+    debug('Queued message for %s (%d pending, %s)', this.name, this._pendingMessages.length, reason);
+    this.status({ fill: 'yellow', shape: 'ring', text: `queued - ${reason} (${this._pendingMessages.length})` });
   }
 
   async _drainPendingMessages() {

--- a/src/hbBaseNode.js
+++ b/src/hbBaseNode.js
@@ -9,6 +9,7 @@ class HbBaseNode {
 
     if (!config.conf) {
       this.error(`Warning: ${config.type} @ (${config.x}, ${config.y}) not connected to a HB Configuration Node`);
+      this.status({ fill: 'red', shape: 'ring', text: 'not configured' });
     }
 
     this.config = config;
@@ -99,7 +100,7 @@ class HbBaseNode {
   }
 
   statusText(message) {
-    return message.slice(0, 20)
+    return message.slice(0, 32)
   }
 
   /**
@@ -110,7 +111,7 @@ class HbBaseNode {
   handleWarning(warning, statusText) {
     this.warn(warning);
     this.status({
-      text: (statusText ? statusText : warning).slice(0, 20),
+      text: (statusText ? statusText : warning).slice(0, 32),
       shape: 'ring',
       fill: 'yellow',
     });
@@ -124,7 +125,7 @@ class HbBaseNode {
   handleError(error, statusText) {
     this.error(error);
     this.status({
-      text: (statusText ? statusText : error).slice(0, 20),
+      text: (statusText ? statusText : error).slice(0, 32),
       shape: 'ring',
       fill: 'red',
     });

--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -8,6 +8,12 @@ const process = require('process');
 // during redeploy. The HapClient is kept alive so mDNS discovery doesn't restart.
 const _persistedClients = new Map();
 
+// Clean up humanType strings from hap-client for display
+const HUMAN_TYPE_DISPLAY = {
+  'Camera Rtp Stream Management': 'Camera',
+  'Fanv2': 'Fan v2',
+};
+
 // Canonical device name — accessoryInformation.Name if set, otherwise serviceName
 function getFriendlyName(service) {
   return service.accessoryInformation.Name || service.serviceName;
@@ -177,14 +183,16 @@ class HBConfigNode {
       .filter(service => !perms || service.serviceCharacteristics.some(c => !c.perms || c.perms.includes(perms)))
       .map(service => {
         const name = getFriendlyName(service);
+        const displayType = HUMAN_TYPE_DISPLAY[service.humanType] || service.humanType;
+        const manufacturer = service.accessoryInformation.Manufacturer;
         return {
           name,
-          fullName: `${name} - ${service.humanType}`,
+          fullName: `${name} - ${displayType} (${manufacturer})`,
           sortName: `${name}:${service.type}`,
           uniqueId: service.uniqueId,
           homebridge: service.instance.name,
           service: service.type,
-          manufacturer: service.accessoryInformation.Manufacturer,
+          manufacturer,
         };
       })
       .sort((a, b) => a.sortName.localeCompare(b.sortName));

--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -64,7 +64,6 @@ class HBConfigNode {
         config: { debug: false },
         pin: config.username
       });
-
       // Stable discovery handler: always delegates to the current config node instance
       // via the persisted state lookup, so it survives config node restarts
       const nodeId = this.id;
@@ -235,10 +234,10 @@ class HBConfigNode {
         }
         return;
       }
-      // Device not in current list — only trigger rediscovery if not already in progress
+      // Device not in current list — refresh directly since instances are already known
       if (!this.refreshInProcess) {
         this.refreshInProcess = true;
-        this.waitForNoMoreDiscoveries();
+        this._scheduleRefresh();
       }
     }
 
@@ -252,6 +251,23 @@ class HBConfigNode {
 
   _findMatchingDevice(deviceId) {
     return this.hbDevices.find(service => deviceId === getDeviceIdentifier(service));
+  }
+
+  _scheduleRefresh() {
+    if (this._refreshTimeout) {
+      clearTimeout(this._refreshTimeout);
+    }
+    // Cancel any pending monitor-only refresh — handleReady will handle the monitor
+    if (this._monitorRefreshTimeout) {
+      clearTimeout(this._monitorRefreshTimeout);
+      this._monitorRefreshTimeout = null;
+    }
+    this._refreshTimeout = setTimeout(() => {
+      this._refreshTimeout = null;
+      this.handleReady()
+        .catch(err => this.error(`Error during device refresh: ${err.message}`))
+        .finally(() => { this.refreshInProcess = false; });
+    }, 500);
   }
 
   _scheduleMonitorRefresh() {
@@ -303,8 +319,19 @@ class HBConfigNode {
         .filter(node => ['hb-status', 'hb-event', 'hb-resume'].includes(node.type))
         .map(node => node.hbDevice) // Map to hbDevice property
         .filter(Boolean); // Remove any undefined or null values, if present;
+
+      // Skip if the monitor already covers the same set of devices
+      if (this.monitor && this._monitorNodeIds) {
+        const currentIds = monitorNodes.map(n => n.uniqueId).sort().join(',');
+        if (currentIds === this._monitorNodeIds) {
+          debug('Monitor already covers same devices, skipping recreation');
+          return;
+        }
+      }
+
       this.log(`Connected to ${monitorNodes.length} Homebridge devices`);
-      // console.log('monitorNodes', monitorNodes);
+      this._monitorNodeIds = monitorNodes.map(n => n.uniqueId).sort().join(',');
+
       if (this.monitor) {
         this._recreatingMonitor = true;
         this.monitor.finish();
@@ -383,6 +410,10 @@ class HBConfigNode {
       clearTimeout(this.discoveryTimeout);
       this.discoveryTimeout = null;
     }
+    if (this._refreshTimeout) {
+      clearTimeout(this._refreshTimeout);
+      this._refreshTimeout = null;
+    }
     if (this._monitorRefreshTimeout) {
       clearTimeout(this._monitorRefreshTimeout);
       this._monitorRefreshTimeout = null;
@@ -392,6 +423,7 @@ class HBConfigNode {
       this._recreatingMonitor = true;
       this.monitor.finish();
       this.monitor = null;
+      this._monitorNodeIds = null;
     }
 
     const persisted = this.id ? _persistedClients.get(this.id) : null;

--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -4,6 +4,20 @@ const fs = require('fs');
 const path = require('path');
 const process = require('process');
 
+// Module-level persisted state: keyed by config node ID, survives config-node restarts
+// during redeploy. The HapClient is kept alive so mDNS discovery doesn't restart.
+const _persistedClients = new Map();
+
+// Canonical device name — accessoryInformation.Name if set, otherwise serviceName
+function getFriendlyName(service) {
+  return service.accessoryInformation.Name || service.serviceName;
+}
+
+// Canonical device identifier — must be the single source of truth for matching
+function getDeviceIdentifier(service) {
+  return `${service.instance.name}${service.instance.username}${service.accessoryInformation.Manufacturer}${getFriendlyName(service)}${service.uuid.slice(0, 8)}`;
+}
+
 class HBConfigNode {
   constructor(config, RED) {
     RED.nodes.createNode(this, config);
@@ -17,21 +31,61 @@ class HBConfigNode {
     this.evDevices = [];
     this.ctDevices = [];
     this.hbDevices = [];
-    this.clientNodes = [];
+    this.clientNodes = {};
     //  this.log = new Log(console, true);
     this.discoveryTimeout = null;
+    this._monitorRefreshTimeout = null;
+    this._recreatingMonitor = false;
 
-    // Initialize HAP client
-    this.hapClient = new HapClient({
-      config: { debug: false },
-      pin: config.username
-    });
+    const persisted = this.id ? _persistedClients.get(this.id) : null;
 
-    this.hapClient.on('instance-discovered', this.waitForNoMoreDiscoveries);
-    this.hapClient.on('discovery-ended', this.hapClient.refreshInstances);
+    if (persisted && persisted.pin === config.username) {
+      // Reuse existing HapClient from previous deploy — avoids 20-second rediscovery
+      this.hapClient = persisted.hapClient;
+      this.hbDevices = persisted.hbDevices;
+      this.evDevices = persisted.evDevices;
+      this.ctDevices = persisted.ctDevices;
+      persisted.currentNode = this;
+      this.refreshInProcess = false;
+      debug('Reusing persisted HapClient with %d devices for config node %s', this.hbDevices.length, this.id);
+    } else {
+      // First startup or PIN changed — create new HapClient
+      if (persisted) {
+        persisted.hapClient.destroy();
+      }
+
+      this.hapClient = new HapClient({
+        config: { debug: false },
+        pin: config.username
+      });
+
+      // Stable discovery handler: always delegates to the current config node instance
+      // via the persisted state lookup, so it survives config node restarts
+      const nodeId = this.id;
+      this.hapClient.on('instance-discovered', (instance) => {
+        const state = nodeId ? _persistedClients.get(nodeId) : null;
+        if (state?.currentNode) {
+          state.currentNode.waitForNoMoreDiscoveries(instance);
+        }
+      });
+      this.hapClient.on('discovery-ended', this.hapClient.refreshInstances);
+
+      if (this.id) {
+        _persistedClients.set(this.id, {
+          hapClient: this.hapClient,
+          pin: config.username,
+          hbDevices: this.hbDevices,
+          evDevices: this.evDevices,
+          ctDevices: this.ctDevices,
+          currentNode: this,
+        });
+      }
+
+      this.refreshInProcess = true;
+    }
+
     if (this.on)
       this.on('close', this.close.bind(this));
-    this.refreshInProcess = true; // Prevents multiple refreshes, hapClient kicks of a discovery on start
   }
 
   /**
@@ -40,20 +94,22 @@ class HBConfigNode {
   waitForNoMoreDiscoveries = (instance) => {
     if (instance)
       debug('Instance discovered: %s - %s %s:%s', instance?.name, instance?.username, instance?.ipAddress, instance?.port);
-    if (!this.discoveryTimeout) {
-      this.discoveryTimeout = setTimeout(() => {
-        this.debug('No more instances discovered, publishing services');
-        this.handleReady();
-        this.discoveryTimeout = null;
-        this.refreshInProcess = false;
-      }, 20000);  // resetInstancePool() triggers a discovery after 6 seconds.  Need to wait for it to finish.
+    if (this.discoveryTimeout) {
+      clearTimeout(this.discoveryTimeout);
     }
+    this.discoveryTimeout = setTimeout(() => {
+      this.debug('No more instances discovered, publishing services');
+      this.discoveryTimeout = null;
+      this.handleReady()
+        .catch(err => this.error(`Error during device initialization: ${err.message}`))
+        .finally(() => { this.refreshInProcess = false; });
+    }, 20000);  // resetInstancePool() triggers a discovery after 6 seconds.  Need to wait for it to finish.
   };
 
   /**
-   * Populate the list of devices and handle duplicates
+   * Refresh the device list from Homebridge instances
    */
-  async handleReady() {
+  async refreshDeviceList() {
     const updatedDevices = await this.hapClient.getAllServices();
     if (this.debugLogging && updatedDevices && updatedDevices.length && process.uptime() < 300) {
       try {
@@ -66,46 +122,71 @@ class HBConfigNode {
     }
     // Fix broken uniqueId's from HAP-Client
     updatedDevices.forEach((service) => {
-      const friendlyName = (service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName);
-      service.uniqueId = `${service.instance.name}${service.instance.username}${service.accessoryInformation.Manufacturer}${friendlyName}${service.uuid.slice(0, 8)}`;
+      service.uniqueId = getDeviceIdentifier(service);
     });
-    updatedDevices.forEach((updatedService, index) => {
-      if (this.hbDevices.find(service => service.uniqueId === updatedService.uniqueId)) {
-        // debug(`Exsiting UniqueID breakdown - ${updatedService.serviceName}-${updatedService.instance.username}-${updatedService.aid}-${updatedService.iid}-${updatedService.type}`);
-        const update = this.hbDevices.find(service => service.uniqueId === updatedService.uniqueId);
-        update.instance = updatedService.instance;
+    // Rebuild device list: update existing, add new, drop stale, deduplicate
+    const existingMap = new Map(this.hbDevices.map(s => [s.uniqueId, s]));
+    const newMap = new Map();
+    updatedDevices.forEach(updatedService => {
+      if (newMap.has(updatedService.uniqueId)) return; // Skip duplicates within batch
+      const existing = existingMap.get(updatedService.uniqueId);
+      if (existing) {
+        // Preserve object reference for clientNode.hbDevice === matchedDevice checks,
+        // but update all properties including method closures bound to the current HapClient
+        Object.assign(existing, updatedService);
+        newMap.set(updatedService.uniqueId, existing);
       } else {
         // debug(`New Service UniqueID breakdown - ${updatedService.serviceName}-${updatedService.instance.username}-${updatedService.aid}-${updatedService.iid}-${updatedService.type}`);
-        this.hbDevices.push(updatedService);
+        newMap.set(updatedService.uniqueId, updatedService);
       }
     });
+    this.hbDevices = Array.from(newMap.values());
     this.evDevices = this.toList({ perms: 'ev' });
     this.ctDevices = this.toList({ perms: 'pw' });
-    this.log(`Devices initialized: evDevices: ${this.evDevices.length}, ctDevices: ${this.ctDevices.length}`);
-    this.handleDuplicates(this.evDevices);
-    this.connectClientNodes();
+
+    // Update persisted state for subsequent deploys
+    const persisted = this.id ? _persistedClients.get(this.id) : null;
+    if (persisted) {
+      persisted.hbDevices = this.hbDevices;
+      persisted.evDevices = this.evDevices;
+      persisted.ctDevices = this.ctDevices;
+    }
   }
 
-  toList(perms) {
+  /**
+   * Populate the list of devices, handle duplicates, and connect client nodes
+   */
+  async handleReady() {
+    await this.refreshDeviceList();
+    this.log(`Devices initialized: evDevices: ${this.evDevices.length}, ctDevices: ${this.ctDevices.length}`);
+    this.handleDuplicates(this.evDevices);
+    await this.connectClientNodes();
+  }
+
+  toList({ perms } = {}) {
     const supportedTypes = new Set([
       'Air Purifier', 'Air Quality Sensor', 'Battery', 'Carbon Dioxide Sensor', 'Carbon Monoxide Sensor', 'Camera Rtp Stream Management',
       'Doorbell', 'Fan', 'Fanv2', 'Garage Door Opener', 'Humidity Sensor', 'Input Source',
       'Leak Sensor', 'Light Sensor', 'Lightbulb', 'Lock Mechanism', 'Motion Sensor', 'Occupancy Sensor',
       'Outlet', 'Smoke Sensor', 'Speaker', 'Stateless Programmable Switch', 'Switch',
       'Television', 'Temperature Sensor', 'Thermostat', 'Contact Sensor',
-      'Window', 'Window Covering', 'Light Sensor'
+      'Window', 'Window Covering'
     ]);
     return filterUnique(this.hbDevices)
       .filter(service => supportedTypes.has(service.humanType))
-      .map(service => ({
-        name: (service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName),
-        fullName: `${(service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName)} - ${service.humanType}`,
-        sortName: `${(service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName)}:${service.type}`,
-        uniqueId: service.uniqueId,
-        homebridge: service.instance.name,
-        service: service.type,
-        manufacturer: service.accessoryInformation.Manufacturer,
-      }))
+      .filter(service => !perms || service.serviceCharacteristics.some(c => !c.perms || c.perms.includes(perms)))
+      .map(service => {
+        const name = getFriendlyName(service);
+        return {
+          name,
+          fullName: `${name} - ${service.humanType}`,
+          sortName: `${name}:${service.type}`,
+          uniqueId: service.uniqueId,
+          homebridge: service.instance.name,
+          service: service.type,
+          manufacturer: service.accessoryInformation.Manufacturer,
+        };
+      })
       .sort((a, b) => a.sortName.localeCompare(b.sortName));
   }
 
@@ -131,65 +212,117 @@ class HBConfigNode {
   registerClientNode(clientNode) {
     debug('Register: %s type: %s', clientNode.type, clientNode.name);
     this.clientNodes[clientNode.id] = clientNode;
+
+    // Connect immediately from existing/cached device list when possible
+    if (this.hbDevices.length > 0) {
+      const matchedDevice = this._findMatchingDevice(clientNode.device);
+      if (matchedDevice) {
+        clientNode.hbDevice = matchedDevice;
+        clientNode.status({ fill: 'green', shape: 'dot', text: 'connected' });
+        // Defer emit so subclass constructors complete before handlers fire
+        process.nextTick(() => clientNode.emit('hbReady', matchedDevice));
+        debug('_Registered: %s type: %s', clientNode.type, matchedDevice.type, matchedDevice.serviceName);
+        if (['hb-status', 'hb-event', 'hb-resume'].includes(clientNode.type)) {
+          this._scheduleMonitorRefresh();
+        }
+        return;
+      }
+      // Device not in current list — only trigger rediscovery if not already in progress
+      if (!this.refreshInProcess) {
+        this.refreshInProcess = true;
+        this.waitForNoMoreDiscoveries();
+      }
+    }
+
     clientNode.status({ fill: 'yellow', shape: 'ring', text: 'connecting' });
-    this.waitForNoMoreDiscoveries(); // Connect new nodes created after startup has ended ( Need a function to rather than brute forcing it )
+  }
+
+  unregisterClientNode(clientNode) {
+    debug('Unregister: %s type: %s', clientNode.type, clientNode.name);
+    delete this.clientNodes[clientNode.id];
+  }
+
+  _findMatchingDevice(deviceId) {
+    return this.hbDevices.find(service => deviceId === getDeviceIdentifier(service));
+  }
+
+  _scheduleMonitorRefresh() {
+    if (this._monitorRefreshTimeout) {
+      clearTimeout(this._monitorRefreshTimeout);
+    }
+    this._monitorRefreshTimeout = setTimeout(() => {
+      this._monitorRefreshTimeout = null;
+      this.monitorDevices()
+        .catch(err => this.error(`Error refreshing monitor: ${err.message}`));
+    }, 500);
   }
 
   async connectClientNodes() {
     debug('connect %s nodes', Object.keys(this.clientNodes).length);
-    for (const [key, clientNode] of Object.entries(this.clientNodes)) {
-      // debug('_Register: %s type: "%s" "%s" "%s"', clientNode.type, clientNode.name, clientNode.instance, clientNode.device);
-      const matchedDevice = this.hbDevices.find(service => {
-        const friendlyName = (service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName);
-        const deviceIdentifier = `${service.instance.name}${service.instance.username}${service.accessoryInformation.Manufacturer}${friendlyName}${service.uuid.slice(0, 8)}`;
-        return clientNode.device === deviceIdentifier;
-      });
+    let changed = false;
+    for (const [, clientNode] of Object.entries(this.clientNodes)) {
+      const matchedDevice = this._findMatchingDevice(clientNode.device);
 
       if (matchedDevice) {
+        // Skip nodes already connected to the same device (preserves status, avoids re-emitting hbReady)
+        if (clientNode.hbDevice === matchedDevice) {
+          debug('_Already connected: %s type: %s', clientNode.type, matchedDevice.type);
+          continue;
+        }
         clientNode.hbDevice = matchedDevice;
         clientNode.status({ fill: 'green', shape: 'dot', text: 'connected' });
         clientNode.emit('hbReady', matchedDevice);
         debug('_Registered: %s type: %s', clientNode.type, matchedDevice.type, matchedDevice.serviceName);
+        changed = true;
       } else {
+        clientNode.hbDevice = null;
         this.error(`ERROR: Device registration failed '${clientNode.fullName}' - '${clientNode.device}'`);
+        clientNode.status({ fill: 'red', shape: 'ring', text: 'not found' });
+        changed = true;
       }
     };
 
-    await this.monitorDevices();
+    // Only recreate the monitor if device assignments actually changed
+    if (changed || !this.monitor) {
+      await this.monitorDevices();
+    }
   }
 
   async monitorDevices() {
     if (Object.keys(this.clientNodes).length) {
 
       const monitorNodes = Object.values(this.clientNodes)
-        .filter(node => ['hb-status', 'hb-event', 'hb-resume'].includes(node.type)) // Filter by type
+        .filter(node => ['hb-status', 'hb-event', 'hb-resume'].includes(node.type))
         .map(node => node.hbDevice) // Map to hbDevice property
         .filter(Boolean); // Remove any undefined or null values, if present;
-      this.log(`Connected to ${Object.keys(monitorNodes).length} Homebridge devices`);
+      this.log(`Connected to ${monitorNodes.length} Homebridge devices`);
       // console.log('monitorNodes', monitorNodes);
       if (this.monitor) {
-        // This is kinda brute force, and should be refactored to only refresh the changed monitorNodes
+        this._recreatingMonitor = true;
         this.monitor.finish();
       }
-      this.monitor = await this.hapClient.monitorCharacteristics(monitorNodes);
+      try {
+        this.monitor = await this.hapClient.monitorCharacteristics(monitorNodes);
+      } finally {
+        this._recreatingMonitor = false;
+      }
       this.monitor.on('service-update', (services) => {
         services.forEach(service => {
-          const eventNodes = Object.values(this.clientNodes).filter(clientNode => {
-            const deviceIdentifier = `${service.instance.name}${service.instance.username}${service.accessoryInformation.Manufacturer}${(service.accessoryInformation.Name ? service.accessoryInformation.Name : service.serviceName)}${service.uuid.slice(0, 8)}`;
-            // debug('service-update: compare', clientNode.config.device, deviceIdentifier);
-            return clientNode.config.device === deviceIdentifier;
-          }
+          const deviceId = getDeviceIdentifier(service);
+          const eventNodes = Object.values(this.clientNodes).filter(
+            clientNode => clientNode.config.device === deviceId
           );
-          // debug('service-update', service.serviceName, eventNodes);
           eventNodes.forEach(eventNode => eventNode.emit('hbEvent', service));
         });
       });
       this.monitor.on('monitor-close', (instance, hadError) => {
+        if (this._recreatingMonitor) return;
         debug('monitor-close', instance.name, instance.ipAddress, instance.port, hadError)
         this.disconnectClientNodes(instance);
         // this.refreshDevices();
       })
       this.monitor.on('monitor-refresh', (instance, hadError) => {
+        if (this._recreatingMonitor) return;
         debug('monitor-refresh', instance.name, instance.ipAddress, instance.port, hadError)
         this.reconnectClientNodes(instance);
         // this.refreshDevices();
@@ -224,9 +357,50 @@ class HBConfigNode {
     });
   }
 
-  close() {
+  close(removed, done) {
     debug('hb-config: close');
-    this.hapClient?.destroy();
+    if (this.discoveryTimeout) {
+      clearTimeout(this.discoveryTimeout);
+      this.discoveryTimeout = null;
+    }
+    if (this._monitorRefreshTimeout) {
+      clearTimeout(this._monitorRefreshTimeout);
+      this._monitorRefreshTimeout = null;
+    }
+    // Finish monitor — it will be recreated when new client nodes register
+    if (this.monitor) {
+      this._recreatingMonitor = true;
+      this.monitor.finish();
+      this.monitor = null;
+    }
+
+    const persisted = this.id ? _persistedClients.get(this.id) : null;
+    if (removed) {
+      // Config node permanently removed — destroy HapClient and clean up
+      if (persisted) {
+        persisted.hapClient.destroy();
+        _persistedClients.delete(this.id);
+      } else {
+        this.hapClient?.destroy();
+      }
+    } else if (persisted) {
+      // Redeploy — persist current state, keep HapClient alive
+      persisted.currentNode = null; // Guard against events during close->constructor gap
+      persisted.hbDevices = this.hbDevices;
+      persisted.evDevices = this.evDevices;
+      persisted.ctDevices = this.ctDevices;
+    } else {
+      this.hapClient?.destroy();
+    }
+
+    if (done) done();
+  }
+
+  static clearPersistedState() {
+    for (const [, state] of _persistedClients) {
+      state.hapClient?.destroy?.();
+    }
+    _persistedClients.clear();
   }
 }
 

--- a/src/hbConfigNode.js
+++ b/src/hbConfigNode.js
@@ -336,7 +336,8 @@ class HBConfigNode {
         // this.refreshDevices();
       })
       this.monitor.on('monitor-error', (instance, hadError) => {
-        debug('monitor-error', instance, hadError)
+        debug('monitor-error', instance, hadError);
+        this.warnClientNodes(instance, 'monitor error');
       })
     }
   }
@@ -350,6 +351,17 @@ class HBConfigNode {
     clientNodes.forEach(clientNode => {
       clientNode.status({ fill: 'red', shape: 'ring', text: 'disconnected' });
       clientNode.emit('hbDisconnected', instance);
+    });
+  }
+
+  warnClientNodes(instance, text) {
+    debug('warnClientNodes', `${instance.ipAddress}:${instance.port}`, text);
+    const clientNodes = Object.values(this.clientNodes).filter(clientNode => {
+      return `${clientNode.hbDevice?.instance.ipAddress}:${clientNode.hbDevice?.instance.port}` === `${instance.ipAddress}:${instance.port}`;
+    });
+
+    clientNodes.forEach(clientNode => {
+      clientNode.status({ fill: 'yellow', shape: 'ring', text });
     });
   }
 

--- a/src/hbConfigNode.test.js
+++ b/src/hbConfigNode.test.js
@@ -37,6 +37,7 @@ describe('Issue 142', () => {
     node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   test('Validate Issue 142 fix', async () => {
@@ -73,6 +74,7 @@ describe('HBConfigNode', () => {
     node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   test('Retrieve devices', async () => {
@@ -109,6 +111,7 @@ describe('from files', () => {
     // node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   // eslint-disable-next-line jest/no-disabled-tests

--- a/src/hbConfigNode.test.js
+++ b/src/hbConfigNode.test.js
@@ -10,6 +10,7 @@ jest.mock('@homebridge/hap-client', () => {
       getAllServices: jest.fn(), // Will be set per test case
       on: jest.fn(), // Mock event listeners
       removeListener: jest.fn(),
+
       connect: jest.fn().mockResolvedValue(true),
       disconnect: jest.fn(),
     })),
@@ -2211,7 +2212,7 @@ const testhbDevices = [
 const testhbDevicesResult = [
   {
     name: 'Backyard',
-    fullName: 'Backyard - Camera Rtp Stream Management',
+    fullName: 'Backyard - Camera (Eufy)',
     sortName: 'Backyard:CameraRTPStreamManagement',
     uniqueId: 'homebridge0E:89:A7:DA:D3:21EufyBackyard00000110',
     homebridge: 'homebridge',
@@ -2220,7 +2221,7 @@ const testhbDevicesResult = [
   },
   {
     name: 'Backyard',
-    fullName: 'Backyard - Motion Sensor',
+    fullName: 'Backyard - Motion Sensor (Eufy)',
     sortName: 'Backyard:MotionSensor',
     uniqueId: 'homebridge0E:89:A7:DA:D3:21EufyBackyard00000085',
     homebridge: 'homebridge',
@@ -2228,7 +2229,7 @@ const testhbDevicesResult = [
     manufacturer: 'Eufy'
   },
   {
-    "fullName": "Canoe 5036 - Camera Rtp Stream Management",
+    "fullName": "Canoe 5036 - Camera (HikVision)",
     "homebridge": "ECI-T24F2",
     "manufacturer": "HikVision",
     "name": "Canoe 5036",
@@ -2237,7 +2238,7 @@ const testhbDevicesResult = [
     "uniqueId": "ECI-T24F25C:EE:FE:4D:64:B4HikVisionCanoe 503600000110",
   },
   {
-    "fullName": "Canoe 5036 - Motion Sensor",
+    "fullName": "Canoe 5036 - Motion Sensor (HikVision)",
     "homebridge": "ECI-T24F2",
     "manufacturer": "HikVision",
     "name": "Canoe 5036",
@@ -2247,7 +2248,7 @@ const testhbDevicesResult = [
   },
   {
     name: 'Side door',
-    fullName: 'Side door - Camera Rtp Stream Management',
+    fullName: 'Side door - Camera (Eufy)',
     sortName: 'Side door:CameraRTPStreamManagement',
     uniqueId: 'homebridge0E:89:A7:DA:D3:21EufySide door00000110',
     homebridge: 'homebridge',
@@ -2256,7 +2257,7 @@ const testhbDevicesResult = [
   },
   {
     name: 'Side door',
-    fullName: 'Side door - Motion Sensor',
+    fullName: 'Side door - Motion Sensor (Eufy)',
     sortName: 'Side door:MotionSensor',
     uniqueId: 'homebridge0E:89:A7:DA:D3:21EufySide door00000085',
     homebridge: 'homebridge',
@@ -2337,7 +2338,7 @@ const testhbDevicesIssue142 = [
 const testhbDevicesResultIssue142 = [
   {
     name: 'Bedroom Curtain',
-    fullName: 'Bedroom Curtain - Window Covering',
+    fullName: 'Bedroom Curtain - Window Covering (Tuya Inc.)',
     sortName: 'Bedroom Curtain:WindowCovering',
     uniqueId: 'Issue1420E:89:A7:DA:D3:21Tuya Inc.Bedroom Curtain0000008C',
     homebridge: 'Issue142',
@@ -2346,7 +2347,7 @@ const testhbDevicesResultIssue142 = [
   },
   {
     name: 'Kitchen Curtain',
-    fullName: 'Kitchen Curtain - Window Covering',
+    fullName: 'Kitchen Curtain - Window Covering (Tuya Inc.)',
     sortName: 'Kitchen Curtain:WindowCovering',
     uniqueId: 'Issue1420E:89:A7:DA:D3:21Tuya Inc.Kitchen Curtain0000008C',
     homebridge: 'Issue142',
@@ -2355,7 +2356,7 @@ const testhbDevicesResultIssue142 = [
   },
   {
     name: 'Livingroom Curtain',
-    fullName: 'Livingroom Curtain - Window Covering',
+    fullName: 'Livingroom Curtain - Window Covering (Tuya Inc.)',
     sortName: 'Livingroom Curtain:WindowCovering',
     uniqueId: 'Issue1420E:89:A7:DA:D3:21Tuya Inc.Livingroom Curtain0000008C',
     homebridge: 'Issue142',

--- a/src/hbConfigNode.test.js
+++ b/src/hbConfigNode.test.js
@@ -37,6 +37,7 @@ describe('Issue 142', () => {
     node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   test('Validate Issue 142 fix', async () => {
@@ -73,6 +74,7 @@ describe('HBConfigNode', () => {
     node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   test('Retrieve devices', async () => {
@@ -109,6 +111,7 @@ describe('from files', () => {
     // node.debug = true;
     node.warn = console.log;
     node.log = console.log;
+    node.error = console.error;
   });
 
   test.skip('Retrieve devices, and compare with current (v2)', async () => {

--- a/src/hbControlNode.js
+++ b/src/hbControlNode.js
@@ -44,6 +44,7 @@ class HbControlNode extends HbBaseNode {
 
     const results = [];
     let fill = 'green';
+    let shape = 'dot';
 
     try {
       if (isCamera) {
@@ -70,13 +71,13 @@ class HbControlNode extends HbBaseNode {
           this.error(`${error.message} for ${JSON.stringify(message.payload)}`);
           results.push({ Error: `${error.message} for ${JSON.stringify(message.payload)}` });
           fill = 'red';
-          this.hbConfigNode.disconnectClientNodes(this.hbDevice.instance);
+          shape = 'ring';
         }
       }
 
       // Update status
       const statusText = this.statusText(JSON.stringify(Object.assign({}, ...results)));
-      this.status({ text: statusText, shape: 'dot', fill });
+      this.status({ text: statusText, shape, fill });
       done();
     } catch (error) {
       this.handleError(error, 'Unhandled error');

--- a/src/hbControlNode.js
+++ b/src/hbControlNode.js
@@ -1,7 +1,7 @@
-const hbBaseNode = require('./hbBaseNode');
+const HbBaseNode = require('./hbBaseNode');
 const debug = require('debug')('hapNodeRed:hbControlNode');
 
-class HbControlNode extends hbBaseNode {
+class HbControlNode extends HbBaseNode {
   constructor(config, RED) {
     super(config, RED);
   }
@@ -11,6 +11,7 @@ class HbControlNode extends hbBaseNode {
 
     if (!this.hbDevice) {
       this.handleWarning('HB not initialized');
+      done('HB not initialized');
       return;
     }
 
@@ -26,12 +27,13 @@ class HbControlNode extends hbBaseNode {
       this.error(
         `Invalid payload. Expected JSON object, e.g., {"On":false, "Brightness":0}. Valid values: ${validNames}`
       );
-      this.status({ text: 'Invalid payload', shape: 'dot', fill: 'red' });
+      this.status({ text: 'Invalid payload', shape: 'ring', fill: 'red' });
+      done();
       return;
     }
 
     // Validate payload
-    let keysToKeep = Object.keys(this.hbDevice.values);
+    const keysToKeep = Object.keys(this.hbDevice.values);
 
     Object.keys(message.payload).forEach(key => {
       if (!keysToKeep.includes(key)) {
@@ -70,28 +72,12 @@ class HbControlNode extends hbBaseNode {
           fill = 'red';
           this.hbConfigNode.disconnectClientNodes(this.hbDevice.instance);
         }
-
-        /*
-        for (const key of Object.keys(message.payload)) {
-          try {
-            debug('Setting value for', key, message.payload[key]);
-            const result = await this.hbDevice.setCharacteristicByType(key, message.payload[key]);
-            results.push({ [result.type]: result.value });
-          } catch (error) {
-            console.log(error)
-            this.error(`Failed to set value for "${key}": ${error.message}`);
-            results.push({ [key]: `Error: ${error.message}` });
-            fill = 'red';
-            this.hbConfigNode.disconnectClientNodes(this.hbDevice.instance);
-          }
-           
-        } */
       }
 
       // Update status
       const statusText = this.statusText(JSON.stringify(Object.assign({}, ...results)));
       this.status({ text: statusText, shape: 'dot', fill });
-      done
+      done();
     } catch (error) {
       this.handleError(error, 'Unhandled error');
       done(`Unhandled error: ${error.message}`);

--- a/src/hbEventNode.js
+++ b/src/hbEventNode.js
@@ -1,7 +1,7 @@
-const hbBaseNode = require('./hbBaseNode');
+const HbBaseNode = require('./hbBaseNode');
 const debug = require('debug')('hapNodeRed:hbEventNode');
 
-class HbEventNode extends hbBaseNode {
+class HbEventNode extends HbBaseNode {
   constructor(config, RED) {
     super(config, RED);
     this.sendInitialState = config.sendInitialState === true;
@@ -9,7 +9,8 @@ class HbEventNode extends hbBaseNode {
 
   handleHbReady(service) {
     debug('handleHbReady', this.id, this.name, service.values)
-    if (this.sendInitialState) {
+    if (this.sendInitialState && !this._initialStateSent) {
+      this._initialStateSent = true;
       this.status({
         text: this.statusText(JSON.stringify(service.values)),
         shape: 'dot',

--- a/src/hbEventNode.js
+++ b/src/hbEventNode.js
@@ -24,7 +24,7 @@ class HbEventNode extends HbBaseNode {
     debug('hbEvent for', this.id, this.type, service.serviceName, JSON.stringify(service.values));
 
     this.status({
-      text: JSON.stringify(service.values),
+      text: this.statusText(JSON.stringify(service.values)),
       shape: 'dot',
       fill: 'green',
     });

--- a/src/hbEventNode.js
+++ b/src/hbEventNode.js
@@ -20,6 +20,10 @@ class HbEventNode extends HbBaseNode {
     }
   }
 
+  handleHbDisconnected() {
+    this._initialStateSent = false;
+  }
+
   handleHBEventMessage(service) {
     debug('hbEvent for', this.id, this.type, service.serviceName, JSON.stringify(service.values));
 

--- a/src/hbResumeNode.js
+++ b/src/hbResumeNode.js
@@ -17,11 +17,12 @@ class HbResumeNode extends HbBaseNode {
     }
   }
 
-  handleInput(message, send) {
+  handleInput(message, send, done) {
     debug('handleInput', this.id, message.payload, this.name);
 
     if (!this.hbDevice) {
       this.handleWarning('HB not initialized');
+      done('HB not initialized');
       return;
     }
 
@@ -33,6 +34,7 @@ class HbResumeNode extends HbBaseNode {
         `Invalid payload. Expected: {"On": false, "Brightness": 0}. Valid values: ${validNames}`,
         'Invalid payload'
       );
+      done();
       return;
     }
 
@@ -54,8 +56,9 @@ class HbResumeNode extends HbBaseNode {
       fill: 'green',
     });
 
-    this.lastOutputTime = Date.now();;
+    this.lastOutputTime = Date.now();
     send(message);
+    done();
   }
 
 }

--- a/src/hbResumeNode.js
+++ b/src/hbResumeNode.js
@@ -8,6 +8,10 @@ class HbResumeNode extends HbBaseNode {
     this.storedState = null;
   }
 
+  handleHbDisconnected() {
+    this.storedState = null;
+  }
+
   handleHBEventMessage(service) {
     debug('hbEvent for', this.id, service.serviceName, JSON.stringify(service.values));
 

--- a/src/hbStatusNode.js
+++ b/src/hbStatusNode.js
@@ -15,21 +15,24 @@ class HbStatusNode extends HbBaseNode {
       return;
     }
 
-    const result = await this.hbDevice.refreshCharacteristics();
-    if (result) {
-      this.status({
-        text: this.statusText(JSON.stringify(result.values)),
-        shape: 'dot',
-        fill: 'green'
-      });
+    try {
+      const result = await this.hbDevice.refreshCharacteristics();
+      if (result) {
+        this.status({
+          text: this.statusText(JSON.stringify(result.values)),
+          shape: 'dot',
+          fill: 'green'
+        });
 
-      send(Object.assign(message, this.createMessage(result)));
-      done();
-    } else {
-      this.status({ fill: "red", shape: "ring", text: "disconnected" });
-      this.error(`No response from device ${this.name}`, message);
-      this.hbConfigNode.disconnectClientNodes(this.hbDevice.instance);
-      done(`No response from device ${this.name}`);
+        send(Object.assign(message, this.createMessage(result)));
+        done();
+      } else {
+        this.handleError(`No response from device ${this.name}`, 'no response');
+        done(`No response from device ${this.name}`);
+      }
+    } catch (error) {
+      this.handleError(error.message, 'error');
+      done(error.message);
     }
 
   }

--- a/src/hbStatusNode.js
+++ b/src/hbStatusNode.js
@@ -11,24 +11,25 @@ class HbStatusNode extends HbBaseNode {
 
     if (!this.hbDevice) {
       this.handleWarning('HB not initialized');
+      done('HB not initialized');
       return;
     }
 
     const result = await this.hbDevice.refreshCharacteristics();
     if (result) {
       this.status({
-        text: this.statusText(JSON.stringify(await this.hbDevice.values)),
+        text: this.statusText(JSON.stringify(result.values)),
         shape: 'dot',
         fill: 'green'
       });
 
       send(Object.assign(message, this.createMessage(result)));
-      done
+      done();
     } else {
       this.status({ fill: "red", shape: "ring", text: "disconnected" });
-      this.error("No response from device", this.name);
+      this.error(`No response from device ${this.name}`, message);
       this.hbConfigNode.disconnectClientNodes(this.hbDevice.instance);
-      done("No response from device");
+      done(`No response from device ${this.name}`);
     }
 
   }

--- a/test/homebridge-automation-hbDevices-v3.json
+++ b/test/homebridge-automation-hbDevices-v3.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Alexa",
-    "fullName": "Alexa - Contact Sensor",
+    "fullName": "Alexa - Contact Sensor (homebridge-alexa)",
     "sortName": "Alexa:ContactSensor",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:37homebridge-alexaAlexa00000080",
     "homebridge": "homebridge",
@@ -10,7 +10,7 @@
   },
   {
     "name": "Alice’s Light",
-    "fullName": "Alice’s Light - Lightbulb",
+    "fullName": "Alice’s Light - Lightbulb (Signify Netherlands B.V.)",
     "sortName": "Alice’s Light:Lightbulb",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:33Signify Netherlands B.V.Alice’s Light00000043",
     "homebridge": "homebridge",
@@ -19,7 +19,7 @@
   },
   {
     "name": "Attic",
-    "fullName": "Attic - Temperature Sensor",
+    "fullName": "Attic - Temperature Sensor (NRCHKB - Acurite-Tower/A)",
     "sortName": "Attic:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - Acurite-Tower/AAttic0000008A",
     "homebridge": "Default Model",
@@ -28,7 +28,7 @@
   },
   {
     "name": "Backyard Tree",
-    "fullName": "Backyard Tree - Temperature Sensor",
+    "fullName": "Backyard Tree - Temperature Sensor (NRCHKB - LaCrosse-TX141Bv3)",
     "sortName": "Backyard Tree:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - LaCrosse-TX141Bv3Backyard Tree0000008A",
     "homebridge": "Default Model",
@@ -37,7 +37,7 @@
   },
   {
     "name": "Backyard",
-    "fullName": "Backyard - Camera Rtp Stream Management",
+    "fullName": "Backyard - Camera (Eufy)",
     "sortName": "Backyard:CameraRTPStreamManagement",
     "uniqueId": "homebridge0E:89:A7:DA:D3:21EufyBackyard00000110",
     "homebridge": "homebridge",
@@ -46,7 +46,7 @@
   },
   {
     "name": "Backyard",
-    "fullName": "Backyard - Humidity Sensor",
+    "fullName": "Backyard - Humidity Sensor (NRCHKB - LaCrosse-TX141W)",
     "sortName": "Backyard:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - LaCrosse-TX141WBackyard00000082",
     "homebridge": "Default Model",
@@ -55,7 +55,7 @@
   },
   {
     "name": "Backyard",
-    "fullName": "Backyard - Motion Sensor",
+    "fullName": "Backyard - Motion Sensor (Eufy)",
     "sortName": "Backyard:MotionSensor",
     "uniqueId": "homebridge0E:89:A7:DA:D3:21EufyBackyard00000085",
     "homebridge": "homebridge",
@@ -64,7 +64,7 @@
   },
   {
     "name": "Backyard",
-    "fullName": "Backyard - Temperature Sensor",
+    "fullName": "Backyard - Temperature Sensor (NRCHKB - LaCrosse-TX141W)",
     "sortName": "Backyard:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - LaCrosse-TX141WBackyard0000008A",
     "homebridge": "Default Model",
@@ -73,7 +73,7 @@
   },
   {
     "name": "Bathroom Fan",
-    "fullName": "Bathroom Fan - Outlet",
+    "fullName": "Bathroom Fan - Outlet (Tasmota)",
     "sortName": "Bathroom Fan:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaBathroom Fan00000047",
     "homebridge": "homebridge",
@@ -82,7 +82,7 @@
   },
   {
     "name": "Bathroom",
-    "fullName": "Bathroom - Humidity Sensor",
+    "fullName": "Bathroom - Humidity Sensor (NRCHKB)",
     "sortName": "Bathroom:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBBathroom00000082",
     "homebridge": "Default Model",
@@ -91,7 +91,7 @@
   },
   {
     "name": "Bathroom",
-    "fullName": "Bathroom - Temperature Sensor",
+    "fullName": "Bathroom - Temperature Sensor (NRCHKB)",
     "sortName": "Bathroom:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBBathroom0000008A",
     "homebridge": "Default Model",
@@ -100,7 +100,7 @@
   },
   {
     "name": "Bunkie Fan Light",
-    "fullName": "Bunkie Fan Light - Lightbulb",
+    "fullName": "Bunkie Fan Light - Lightbulb (Tasmota)",
     "sortName": "Bunkie Fan Light:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaBunkie Fan Light00000043",
     "homebridge": "homebridge",
@@ -109,7 +109,7 @@
   },
   {
     "name": "Bunkie Fan",
-    "fullName": "Bunkie Fan - Fan",
+    "fullName": "Bunkie Fan - Fan (Tasmota)",
     "sortName": "Bunkie Fan:Fan",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaBunkie Fan00000040",
     "homebridge": "homebridge",
@@ -118,7 +118,7 @@
   },
   {
     "name": "Bunkie Group",
-    "fullName": "Bunkie Group - Lightbulb",
+    "fullName": "Bunkie Group - Lightbulb (NRCHKB)",
     "sortName": "Bunkie Group:Lightbulb",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBBunkie Group00000043",
     "homebridge": "Default Model",
@@ -127,7 +127,7 @@
   },
   {
     "name": "Bunkie Light",
-    "fullName": "Bunkie Light - Lightbulb",
+    "fullName": "Bunkie Light - Lightbulb (Tasmota)",
     "sortName": "Bunkie Light:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaBunkie Light00000043",
     "homebridge": "homebridge",
@@ -136,7 +136,7 @@
   },
   {
     "name": "Bunkie Lower",
-    "fullName": "Bunkie Lower - Lightbulb",
+    "fullName": "Bunkie Lower - Lightbulb (WLED)",
     "sortName": "Bunkie Lower:Lightbulb",
     "uniqueId": "homebridge0E:03:4B:B3:AF:4CWLEDBunkie Lower00000043",
     "homebridge": "homebridge",
@@ -145,7 +145,7 @@
   },
   {
     "name": "Bunkie Upper",
-    "fullName": "Bunkie Upper - Lightbulb",
+    "fullName": "Bunkie Upper - Lightbulb (Tasmota)",
     "sortName": "Bunkie Upper:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaBunkie Upper00000043",
     "homebridge": "homebridge",
@@ -154,7 +154,7 @@
   },
   {
     "name": "Bunkie",
-    "fullName": "Bunkie - Humidity Sensor",
+    "fullName": "Bunkie - Humidity Sensor (NRCHKB - OMG)",
     "sortName": "Bunkie:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGBunkie00000082",
     "homebridge": "Default Model",
@@ -163,7 +163,7 @@
   },
   {
     "name": "Bunkie",
-    "fullName": "Bunkie - Temperature Sensor",
+    "fullName": "Bunkie - Temperature Sensor (NRCHKB - OMG)",
     "sortName": "Bunkie:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGBunkie0000008A",
     "homebridge": "Default Model",
@@ -172,7 +172,7 @@
   },
   {
     "name": "Busy Bee",
-    "fullName": "Busy Bee - Contact Sensor",
+    "fullName": "Busy Bee - Contact Sensor (Shark)",
     "sortName": "Busy Bee:ContactSensor",
     "uniqueId": "homebridge0E:D3:21:BA:8C:5CSharkBusy Bee00000080",
     "homebridge": "homebridge",
@@ -181,7 +181,7 @@
   },
   {
     "name": "Busy Bee",
-    "fullName": "Busy Bee - Fanv2",
+    "fullName": "Busy Bee - Fan v2 (Shark)",
     "sortName": "Busy Bee:Fanv2",
     "uniqueId": "homebridge0E:D3:21:BA:8C:5CSharkBusy Bee000000B7",
     "homebridge": "homebridge",
@@ -190,7 +190,7 @@
   },
   {
     "name": "Busy Bee",
-    "fullName": "Busy Bee - Switch",
+    "fullName": "Busy Bee - Switch (Shark)",
     "sortName": "Busy Bee:Switch",
     "uniqueId": "homebridge0E:D3:21:BA:8C:5CSharkBusy Bee00000049",
     "homebridge": "homebridge",
@@ -199,7 +199,7 @@
   },
   {
     "name": "Canoe 5036",
-    "fullName": "Canoe 5036 - Camera Rtp Stream Management",
+    "fullName": "Canoe 5036 - Camera (HikVision)",
     "sortName": "Canoe 5036:CameraRTPStreamManagement",
     "uniqueId": "ECI-T24F25C:EE:FE:4D:64:B4HikVisionCanoe 503600000110",
     "homebridge": "ECI-T24F2",
@@ -208,7 +208,7 @@
   },
   {
     "name": "Canoe 5036",
-    "fullName": "Canoe 5036 - Motion Sensor",
+    "fullName": "Canoe 5036 - Motion Sensor (HikVision)",
     "sortName": "Canoe 5036:MotionSensor",
     "uniqueId": "ECI-T24F25C:EE:FE:4D:64:B4HikVisionCanoe 503600000085",
     "homebridge": "ECI-T24F2",
@@ -217,7 +217,7 @@
   },
   {
     "name": "Cottage Main 8365",
-    "fullName": "Cottage Main 8365 - Input Source",
+    "fullName": "Cottage Main 8365 - Input Source (Apple Inc.)",
     "sortName": "Cottage Main 8365:InputSource",
     "uniqueId": "Apple TV 432:6C:6C:2B:4F:33Apple Inc.Cottage Main 8365000000D9",
     "homebridge": "Apple TV 4",
@@ -226,7 +226,7 @@
   },
   {
     "name": "Cottage Main 8365",
-    "fullName": "Cottage Main 8365 - Speaker",
+    "fullName": "Cottage Main 8365 - Speaker (Apple Inc.)",
     "sortName": "Cottage Main 8365:Speaker",
     "uniqueId": "Apple TV 432:6C:6C:2B:4F:33Apple Inc.Cottage Main 836500000113",
     "homebridge": "Apple TV 4",
@@ -235,7 +235,7 @@
   },
   {
     "name": "Cottage Main 8365",
-    "fullName": "Cottage Main 8365 - Television",
+    "fullName": "Cottage Main 8365 - Television (Apple Inc.)",
     "sortName": "Cottage Main 8365:Television",
     "uniqueId": "Apple TV 432:6C:6C:2B:4F:33Apple Inc.Cottage Main 8365000000D8",
     "homebridge": "Apple TV 4",
@@ -244,7 +244,7 @@
   },
   {
     "name": "Deck 6EED",
-    "fullName": "Deck 6EED - Camera Rtp Stream Management",
+    "fullName": "Deck 6EED - Camera (HikVision)",
     "sortName": "Deck 6EED:CameraRTPStreamManagement",
     "uniqueId": "ECI-T24F28E:88:AB:7A:D0:54HikVisionDeck 6EED00000110",
     "homebridge": "ECI-T24F2",
@@ -253,7 +253,7 @@
   },
   {
     "name": "Deck 6EED",
-    "fullName": "Deck 6EED - Motion Sensor",
+    "fullName": "Deck 6EED - Motion Sensor (HikVision)",
     "sortName": "Deck 6EED:MotionSensor",
     "uniqueId": "ECI-T24F28E:88:AB:7A:D0:54HikVisionDeck 6EED00000085",
     "homebridge": "ECI-T24F2",
@@ -262,7 +262,7 @@
   },
   {
     "name": "Deck Light",
-    "fullName": "Deck Light - Lightbulb",
+    "fullName": "Deck Light - Lightbulb (Tasmota)",
     "sortName": "Deck Light:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDeck Light00000043",
     "homebridge": "homebridge",
@@ -271,7 +271,7 @@
   },
   {
     "name": "Dining Room Chandelier",
-    "fullName": "Dining Room Chandelier - Lightbulb",
+    "fullName": "Dining Room Chandelier - Lightbulb (Tasmota)",
     "sortName": "Dining Room Chandelier:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDining Room Chandelier00000043",
     "homebridge": "homebridge",
@@ -280,7 +280,7 @@
   },
   {
     "name": "Door Power",
-    "fullName": "Door Power - Outlet",
+    "fullName": "Door Power - Outlet (Tasmota)",
     "sortName": "Door Power:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDoor Power00000047",
     "homebridge": "homebridge",
@@ -289,7 +289,7 @@
   },
   {
     "name": "Doorbell Button",
-    "fullName": "Doorbell Button - Humidity Sensor",
+    "fullName": "Doorbell Button - Humidity Sensor (Tasmota)",
     "sortName": "Doorbell Button:HumiditySensor",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDoorbell Button00000082",
     "homebridge": "homebridge",
@@ -298,7 +298,7 @@
   },
   {
     "name": "Doorbell Button",
-    "fullName": "Doorbell Button - Outlet",
+    "fullName": "Doorbell Button - Outlet (Tasmota)",
     "sortName": "Doorbell Button:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDoorbell Button00000047",
     "homebridge": "homebridge",
@@ -307,7 +307,7 @@
   },
   {
     "name": "Doorbell Button",
-    "fullName": "Doorbell Button - Temperature Sensor",
+    "fullName": "Doorbell Button - Temperature Sensor (Tasmota)",
     "sortName": "Doorbell Button:TemperatureSensor",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDoorbell Button0000008A",
     "homebridge": "homebridge",
@@ -316,7 +316,7 @@
   },
   {
     "name": "Driveway 8E52",
-    "fullName": "Driveway 8E52 - Camera Rtp Stream Management",
+    "fullName": "Driveway 8E52 - Camera (HikVision)",
     "sortName": "Driveway 8E52:CameraRTPStreamManagement",
     "uniqueId": "ECI-T24F2CB:6F:94:DD:43:77HikVisionDriveway 8E5200000110",
     "homebridge": "ECI-T24F2",
@@ -325,7 +325,7 @@
   },
   {
     "name": "Driveway 8E52",
-    "fullName": "Driveway 8E52 - Motion Sensor",
+    "fullName": "Driveway 8E52 - Motion Sensor (HikVision)",
     "sortName": "Driveway 8E52:MotionSensor",
     "uniqueId": "ECI-T24F2CB:6F:94:DD:43:77HikVisionDriveway 8E5200000085",
     "homebridge": "ECI-T24F2",
@@ -334,7 +334,7 @@
   },
   {
     "name": "Dryer Power",
-    "fullName": "Dryer Power - Outlet",
+    "fullName": "Dryer Power - Outlet (Tasmota)",
     "sortName": "Dryer Power:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaDryer Power00000047",
     "homebridge": "homebridge",
@@ -343,7 +343,7 @@
   },
   {
     "name": "Dryer Working",
-    "fullName": "Dryer Working - Contact Sensor",
+    "fullName": "Dryer Working - Contact Sensor (NRCHKB)",
     "sortName": "Dryer Working:ContactSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBDryer Working00000080",
     "homebridge": "Default Model",
@@ -352,7 +352,7 @@
   },
   {
     "name": "East Bedroom",
-    "fullName": "East Bedroom - Fan",
+    "fullName": "East Bedroom - Fan (Tasmota)",
     "sortName": "East Bedroom:Fan",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaEast Bedroom00000040",
     "homebridge": "homebridge",
@@ -361,7 +361,7 @@
   },
   {
     "name": "East Bedroom",
-    "fullName": "East Bedroom - Lightbulb",
+    "fullName": "East Bedroom - Lightbulb (Tasmota)",
     "sortName": "East Bedroom:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaEast Bedroom00000043",
     "homebridge": "homebridge",
@@ -370,7 +370,7 @@
   },
   {
     "name": "Evening Lights",
-    "fullName": "Evening Lights - Lightbulb",
+    "fullName": "Evening Lights - Lightbulb (Node Red)",
     "sortName": "Evening Lights:Lightbulb",
     "uniqueId": "Default Model69:62:B7:AE:38:D4Node RedEvening Lights00000043",
     "homebridge": "Default Model",
@@ -379,7 +379,7 @@
   },
   {
     "name": "Firepit light",
-    "fullName": "Firepit light - Lightbulb",
+    "fullName": "Firepit light - Lightbulb (Tasmota)",
     "sortName": "Firepit light:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaFirepit light00000043",
     "homebridge": "homebridge",
@@ -388,7 +388,7 @@
   },
   {
     "name": "Floor Lamp One",
-    "fullName": "Floor Lamp One - Lightbulb",
+    "fullName": "Floor Lamp One - Lightbulb (Signify Netherlands B.V.)",
     "sortName": "Floor Lamp One:Lightbulb",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:33Signify Netherlands B.V.Floor Lamp One00000043",
     "homebridge": "homebridge",
@@ -397,7 +397,7 @@
   },
   {
     "name": "Floor Lamp Two",
-    "fullName": "Floor Lamp Two - Lightbulb",
+    "fullName": "Floor Lamp Two - Lightbulb (Signify Netherlands B.V.)",
     "sortName": "Floor Lamp Two:Lightbulb",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:33Signify Netherlands B.V.Floor Lamp Two00000043",
     "homebridge": "homebridge",
@@ -406,7 +406,7 @@
   },
   {
     "name": "Freezer",
-    "fullName": "Freezer - Temperature Sensor",
+    "fullName": "Freezer - Temperature Sensor (NRCHKB - Acurite-986/2F)",
     "sortName": "Freezer:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - Acurite-986/2FFreezer0000008A",
     "homebridge": "Default Model",
@@ -415,7 +415,7 @@
   },
   {
     "name": "Fridge",
-    "fullName": "Fridge - Temperature Sensor",
+    "fullName": "Fridge - Temperature Sensor (NRCHKB - Acurite-986/1R)",
     "sortName": "Fridge:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - Acurite-986/1RFridge0000008A",
     "homebridge": "Default Model",
@@ -424,7 +424,7 @@
   },
   {
     "name": "Front Hall",
-    "fullName": "Front Hall - Lightbulb",
+    "fullName": "Front Hall - Lightbulb (Tasmota)",
     "sortName": "Front Hall:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaFront Hall00000043",
     "homebridge": "homebridge",
@@ -433,7 +433,7 @@
   },
   {
     "name": "Front Soffit",
-    "fullName": "Front Soffit - Lightbulb",
+    "fullName": "Front Soffit - Lightbulb (Tasmota)",
     "sortName": "Front Soffit:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaFront Soffit00000043",
     "homebridge": "homebridge",
@@ -442,7 +442,7 @@
   },
   {
     "name": "Garage Door",
-    "fullName": "Garage Door - Garage Door Opener",
+    "fullName": "Garage Door - Garage Door Opener (Tasmota)",
     "sortName": "Garage Door:GarageDoorOpener",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaGarage Door00000041",
     "homebridge": "homebridge",
@@ -451,7 +451,7 @@
   },
   {
     "name": "Garage Soffit",
-    "fullName": "Garage Soffit - Lightbulb",
+    "fullName": "Garage Soffit - Lightbulb (Tasmota)",
     "sortName": "Garage Soffit:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaGarage Soffit00000043",
     "homebridge": "homebridge",
@@ -460,7 +460,7 @@
   },
   {
     "name": "Greeni",
-    "fullName": "Greeni - Outlet",
+    "fullName": "Greeni - Outlet (Tasmota)",
     "sortName": "Greeni:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaGreeni00000047",
     "homebridge": "homebridge",
@@ -469,7 +469,7 @@
   },
   {
     "name": "Hue Bridge",
-    "fullName": "Hue Bridge - Stateless Programmable Switch",
+    "fullName": "Hue Bridge - Stateless Programmable Switch (Signify Netherlands B.V.)",
     "sortName": "Hue Bridge:StatelessProgrammableSwitch",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:33Signify Netherlands B.V.Hue Bridge00000089",
     "homebridge": "homebridge",
@@ -478,7 +478,7 @@
   },
   {
     "name": "Laundry",
-    "fullName": "Laundry - Humidity Sensor",
+    "fullName": "Laundry - Humidity Sensor (NRCHKB - OMG)",
     "sortName": "Laundry:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGLaundry00000082",
     "homebridge": "Default Model",
@@ -487,7 +487,7 @@
   },
   {
     "name": "Laundry",
-    "fullName": "Laundry - Lightbulb",
+    "fullName": "Laundry - Lightbulb (Tasmota)",
     "sortName": "Laundry:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaLaundry00000043",
     "homebridge": "homebridge",
@@ -496,7 +496,7 @@
   },
   {
     "name": "Laundry",
-    "fullName": "Laundry - Temperature Sensor",
+    "fullName": "Laundry - Temperature Sensor (NRCHKB - OMG)",
     "sortName": "Laundry:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGLaundry0000008A",
     "homebridge": "Default Model",
@@ -505,7 +505,7 @@
   },
   {
     "name": "Main Room Group",
-    "fullName": "Main Room Group - Lightbulb",
+    "fullName": "Main Room Group - Lightbulb (Node Red)",
     "sortName": "Main Room Group:Lightbulb",
     "uniqueId": "Default Model69:62:B7:AE:38:D4Node RedMain Room Group00000043",
     "homebridge": "Default Model",
@@ -514,7 +514,7 @@
   },
   {
     "name": "Master Lights",
-    "fullName": "Master Lights - Lightbulb",
+    "fullName": "Master Lights - Lightbulb (Node Red)",
     "sortName": "Master Lights:Lightbulb",
     "uniqueId": "Default Model69:62:B7:AE:38:D4Node RedMaster Lights00000043",
     "homebridge": "Default Model",
@@ -523,7 +523,7 @@
   },
   {
     "name": "Master",
-    "fullName": "Master - Fan",
+    "fullName": "Master - Fan (Tasmota)",
     "sortName": "Master:Fan",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaMaster00000040",
     "homebridge": "homebridge",
@@ -532,7 +532,7 @@
   },
   {
     "name": "Master",
-    "fullName": "Master - Lightbulb",
+    "fullName": "Master - Lightbulb (Tasmota)",
     "sortName": "Master:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaMaster00000043",
     "homebridge": "homebridge",
@@ -541,7 +541,7 @@
   },
   {
     "name": "Music Port",
-    "fullName": "Music Port - Switch",
+    "fullName": "Music Port - Switch (HTTP-IRBlaster)",
     "sortName": "Music Port:Switch",
     "uniqueId": "homebridgeBC:22:3D:E3:CF:43HTTP-IRBlasterMusic Port00000049",
     "homebridge": "homebridge",
@@ -550,7 +550,7 @@
   },
   {
     "name": "Patio Door",
-    "fullName": "Patio Door - Battery",
+    "fullName": "Patio Door - Battery (SONOFF)",
     "sortName": "Patio Door:Battery",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFPatio Door00000096",
     "homebridge": "homebridge",
@@ -559,7 +559,7 @@
   },
   {
     "name": "Patio Door",
-    "fullName": "Patio Door - Contact Sensor",
+    "fullName": "Patio Door - Contact Sensor (SONOFF)",
     "sortName": "Patio Door:ContactSensor",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFPatio Door00000080",
     "homebridge": "homebridge",
@@ -568,7 +568,7 @@
   },
   {
     "name": "Patio Room",
-    "fullName": "Patio Room - Fan",
+    "fullName": "Patio Room - Fan (Hunter Fan)",
     "sortName": "Patio Room:Fan",
     "uniqueId": "homebridge0E:F4:E9:FC:AD:D1Hunter FanPatio Room00000040",
     "homebridge": "homebridge",
@@ -577,7 +577,7 @@
   },
   {
     "name": "Patio Room",
-    "fullName": "Patio Room - Humidity Sensor",
+    "fullName": "Patio Room - Humidity Sensor (NRCHKB - OMG)",
     "sortName": "Patio Room:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGPatio Room00000082",
     "homebridge": "Default Model",
@@ -586,7 +586,7 @@
   },
   {
     "name": "Patio Room",
-    "fullName": "Patio Room - Lightbulb",
+    "fullName": "Patio Room - Lightbulb (Hunter Fan)",
     "sortName": "Patio Room:Lightbulb",
     "uniqueId": "homebridge0E:F4:E9:FC:AD:D1Hunter FanPatio Room00000043",
     "homebridge": "homebridge",
@@ -595,7 +595,7 @@
   },
   {
     "name": "Patio Room",
-    "fullName": "Patio Room - Temperature Sensor",
+    "fullName": "Patio Room - Temperature Sensor (NRCHKB - OMG)",
     "sortName": "Patio Room:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - OMGPatio Room0000008A",
     "homebridge": "Default Model",
@@ -604,7 +604,7 @@
   },
   {
     "name": "Porch B6AE",
-    "fullName": "Porch B6AE - Camera Rtp Stream Management",
+    "fullName": "Porch B6AE - Camera (HikVision)",
     "sortName": "Porch B6AE:CameraRTPStreamManagement",
     "uniqueId": "ECI-T24F2C1:BB:DE:42:A5:39HikVisionPorch B6AE00000110",
     "homebridge": "ECI-T24F2",
@@ -613,7 +613,7 @@
   },
   {
     "name": "Porch B6AE",
-    "fullName": "Porch B6AE - Doorbell",
+    "fullName": "Porch B6AE - Doorbell (HikVision)",
     "sortName": "Porch B6AE:Doorbell",
     "uniqueId": "ECI-T24F2C1:BB:DE:42:A5:39HikVisionPorch B6AE00000121",
     "homebridge": "ECI-T24F2",
@@ -622,7 +622,7 @@
   },
   {
     "name": "Porch B6AE",
-    "fullName": "Porch B6AE - Motion Sensor",
+    "fullName": "Porch B6AE - Motion Sensor (HikVision)",
     "sortName": "Porch B6AE:MotionSensor",
     "uniqueId": "ECI-T24F2C1:BB:DE:42:A5:39HikVisionPorch B6AE00000085",
     "homebridge": "ECI-T24F2",
@@ -631,7 +631,7 @@
   },
   {
     "name": "Porch B6AE",
-    "fullName": "Porch B6AE - Switch",
+    "fullName": "Porch B6AE - Switch (HikVision)",
     "sortName": "Porch B6AE:Switch",
     "uniqueId": "ECI-T24F2C1:BB:DE:42:A5:39HikVisionPorch B6AE00000049",
     "homebridge": "ECI-T24F2",
@@ -640,7 +640,7 @@
   },
   {
     "name": "Porch Light Strip",
-    "fullName": "Porch Light Strip - Lightbulb",
+    "fullName": "Porch Light Strip - Lightbulb (WLED)",
     "sortName": "Porch Light Strip:Lightbulb",
     "uniqueId": "homebridge0E:03:4B:B3:AF:4CWLEDPorch Light Strip00000043",
     "homebridge": "homebridge",
@@ -649,7 +649,7 @@
   },
   {
     "name": "Porch",
-    "fullName": "Porch - Humidity Sensor",
+    "fullName": "Porch - Humidity Sensor (NRCHKB - Acurite-Tower/B)",
     "sortName": "Porch:HumiditySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - Acurite-Tower/BPorch00000082",
     "homebridge": "Default Model",
@@ -658,7 +658,7 @@
   },
   {
     "name": "Porch",
-    "fullName": "Porch - Temperature Sensor",
+    "fullName": "Porch - Temperature Sensor (NRCHKB - Acurite-Tower/B)",
     "sortName": "Porch:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKB - Acurite-Tower/BPorch0000008A",
     "homebridge": "Default Model",
@@ -667,7 +667,7 @@
   },
   {
     "name": "Portable Fan",
-    "fullName": "Portable Fan - Outlet",
+    "fullName": "Portable Fan - Outlet (Tasmota)",
     "sortName": "Portable Fan:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaPortable Fan00000047",
     "homebridge": "homebridge",
@@ -676,7 +676,7 @@
   },
   {
     "name": "Powder Fan",
-    "fullName": "Powder Fan - Outlet",
+    "fullName": "Powder Fan - Outlet (Tasmota)",
     "sortName": "Powder Fan:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaPowder Fan00000047",
     "homebridge": "homebridge",
@@ -685,7 +685,7 @@
   },
   {
     "name": "Powder Shower",
-    "fullName": "Powder Shower - Lightbulb",
+    "fullName": "Powder Shower - Lightbulb (Tasmota)",
     "sortName": "Powder Shower:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaPowder Shower00000043",
     "homebridge": "homebridge",
@@ -694,7 +694,7 @@
   },
   {
     "name": "Powder",
-    "fullName": "Powder - Lightbulb",
+    "fullName": "Powder - Lightbulb (Tasmota)",
     "sortName": "Powder:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaPowder00000043",
     "homebridge": "homebridge",
@@ -703,7 +703,7 @@
   },
   {
     "name": "Presence",
-    "fullName": "Presence - Occupancy Sensor",
+    "fullName": "Presence - Occupancy Sensor (NRCHKB)",
     "sortName": "Presence:OccupancySensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBPresence00000086",
     "homebridge": "Default Model",
@@ -712,7 +712,7 @@
   },
   {
     "name": "Presence",
-    "fullName": "Presence - Switch",
+    "fullName": "Presence - Switch (NRCHKB)",
     "sortName": "Presence:Switch",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBPresence00000049",
     "homebridge": "Default Model",
@@ -721,7 +721,7 @@
   },
   {
     "name": "Router Power",
-    "fullName": "Router Power - Outlet",
+    "fullName": "Router Power - Outlet (Tasmota)",
     "sortName": "Router Power:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaRouter Power00000047",
     "homebridge": "homebridge",
@@ -730,7 +730,7 @@
   },
   {
     "name": "Shed Door",
-    "fullName": "Shed Door - Battery",
+    "fullName": "Shed Door - Battery (SONOFF)",
     "sortName": "Shed Door:Battery",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFShed Door00000096",
     "homebridge": "homebridge",
@@ -739,7 +739,7 @@
   },
   {
     "name": "Shed Door",
-    "fullName": "Shed Door - Contact Sensor",
+    "fullName": "Shed Door - Contact Sensor (SONOFF)",
     "sortName": "Shed Door:ContactSensor",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFShed Door00000080",
     "homebridge": "homebridge",
@@ -748,7 +748,7 @@
   },
   {
     "name": "Shed Garage Door",
-    "fullName": "Shed Garage Door - Battery",
+    "fullName": "Shed Garage Door - Battery (SONOFF)",
     "sortName": "Shed Garage Door:Battery",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFShed Garage Door00000096",
     "homebridge": "homebridge",
@@ -757,7 +757,7 @@
   },
   {
     "name": "Shed Garage Door",
-    "fullName": "Shed Garage Door - Contact Sensor",
+    "fullName": "Shed Garage Door - Contact Sensor (SONOFF)",
     "sortName": "Shed Garage Door:ContactSensor",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFShed Garage Door00000080",
     "homebridge": "homebridge",
@@ -766,7 +766,7 @@
   },
   {
     "name": "Shed Light",
-    "fullName": "Shed Light - Lightbulb",
+    "fullName": "Shed Light - Lightbulb (Tasmota)",
     "sortName": "Shed Light:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaShed Light00000043",
     "homebridge": "homebridge",
@@ -775,7 +775,7 @@
   },
   {
     "name": "Side Counter",
-    "fullName": "Side Counter - Lightbulb",
+    "fullName": "Side Counter - Lightbulb (Tasmota)",
     "sortName": "Side Counter:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaSide Counter00000043",
     "homebridge": "homebridge",
@@ -784,7 +784,7 @@
   },
   {
     "name": "Side Counter",
-    "fullName": "Side Counter - Outlet",
+    "fullName": "Side Counter - Outlet (Tasmota)",
     "sortName": "Side Counter:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaSide Counter00000047",
     "homebridge": "homebridge",
@@ -793,7 +793,7 @@
   },
   {
     "name": "Side Door",
-    "fullName": "Side Door - Battery",
+    "fullName": "Side Door - Battery (SONOFF)",
     "sortName": "Side Door:Battery",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFSide Door00000096",
     "homebridge": "homebridge",
@@ -802,7 +802,7 @@
   },
   {
     "name": "Side door",
-    "fullName": "Side door - Camera Rtp Stream Management",
+    "fullName": "Side door - Camera (Eufy)",
     "sortName": "Side door:CameraRTPStreamManagement",
     "uniqueId": "homebridge0E:89:A7:DA:D3:21EufySide door00000110",
     "homebridge": "homebridge",
@@ -811,7 +811,7 @@
   },
   {
     "name": "Side Door",
-    "fullName": "Side Door - Contact Sensor",
+    "fullName": "Side Door - Contact Sensor (SONOFF)",
     "sortName": "Side Door:ContactSensor",
     "uniqueId": "homebridge0E:BA:1B:4F:CA:8DSONOFFSide Door00000080",
     "homebridge": "homebridge",
@@ -820,7 +820,7 @@
   },
   {
     "name": "Side door",
-    "fullName": "Side door - Motion Sensor",
+    "fullName": "Side door - Motion Sensor (Eufy)",
     "sortName": "Side door:MotionSensor",
     "uniqueId": "homebridge0E:89:A7:DA:D3:21EufySide door00000085",
     "homebridge": "homebridge",
@@ -829,7 +829,7 @@
   },
   {
     "name": "Small Fridge",
-    "fullName": "Small Fridge - Temperature Sensor",
+    "fullName": "Small Fridge - Temperature Sensor (NRCHKB)",
     "sortName": "Small Fridge:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBSmall Fridge0000008A",
     "homebridge": "Default Model",
@@ -838,7 +838,7 @@
   },
   {
     "name": "Spare",
-    "fullName": "Spare - Temperature Sensor",
+    "fullName": "Spare - Temperature Sensor (NRCHKB)",
     "sortName": "Spare:TemperatureSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBSpare0000008A",
     "homebridge": "Default Model",
@@ -847,7 +847,7 @@
   },
   {
     "name": "Stereo",
-    "fullName": "Stereo - Fan",
+    "fullName": "Stereo - Fan (HTTP-IRBlaster)",
     "sortName": "Stereo:Fan",
     "uniqueId": "homebridgeBC:22:3D:E3:CF:44HTTP-IRBlasterStereo00000040",
     "homebridge": "homebridge",
@@ -856,7 +856,7 @@
   },
   {
     "name": "Table Light",
-    "fullName": "Table Light - Lightbulb",
+    "fullName": "Table Light - Lightbulb (Signify Netherlands B.V.)",
     "sortName": "Table Light:Lightbulb",
     "uniqueId": "homebridgeCC:22:3D:E3:CF:33Signify Netherlands B.V.Table Light00000043",
     "homebridge": "homebridge",
@@ -865,7 +865,7 @@
   },
   {
     "name": "Trailer Power",
-    "fullName": "Trailer Power - Outlet",
+    "fullName": "Trailer Power - Outlet (Tasmota)",
     "sortName": "Trailer Power:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaTrailer Power00000047",
     "homebridge": "homebridge",
@@ -874,7 +874,7 @@
   },
   {
     "name": "Tuner",
-    "fullName": "Tuner - Switch",
+    "fullName": "Tuner - Switch (HTTP-IRBlaster)",
     "sortName": "Tuner:Switch",
     "uniqueId": "homebridgeBC:22:3D:E3:CF:42HTTP-IRBlasterTuner00000049",
     "homebridge": "homebridge",
@@ -883,7 +883,7 @@
   },
   {
     "name": "Wasaga",
-    "fullName": "Wasaga - Thermostat",
+    "fullName": "Wasaga - Thermostat (TCC)",
     "sortName": "Wasaga:Thermostat",
     "uniqueId": "homebridgeAC:22:3D:E3:CF:33TCCWasaga0000004A",
     "homebridge": "homebridge",
@@ -892,7 +892,7 @@
   },
   {
     "name": "Washer Power",
-    "fullName": "Washer Power - Outlet",
+    "fullName": "Washer Power - Outlet (Tasmota)",
     "sortName": "Washer Power:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWasher Power00000047",
     "homebridge": "homebridge",
@@ -901,7 +901,7 @@
   },
   {
     "name": "Washer Working",
-    "fullName": "Washer Working - Contact Sensor",
+    "fullName": "Washer Working - Contact Sensor (NRCHKB)",
     "sortName": "Washer Working:ContactSensor",
     "uniqueId": "Default Model69:62:B7:AE:38:D4NRCHKBWasher Working00000080",
     "homebridge": "Default Model",
@@ -910,7 +910,7 @@
   },
   {
     "name": "Water Meter",
-    "fullName": "Water Meter - Humidity Sensor",
+    "fullName": "Water Meter - Humidity Sensor (Tasmota)",
     "sortName": "Water Meter:HumiditySensor",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWater Meter00000082",
     "homebridge": "homebridge",
@@ -919,7 +919,7 @@
   },
   {
     "name": "Water Meter",
-    "fullName": "Water Meter - Temperature Sensor",
+    "fullName": "Water Meter - Temperature Sensor (Tasmota)",
     "sortName": "Water Meter:TemperatureSensor",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWater Meter0000008A",
     "homebridge": "homebridge",
@@ -928,7 +928,7 @@
   },
   {
     "name": "Water Valve",
-    "fullName": "Water Valve - Outlet",
+    "fullName": "Water Valve - Outlet (Tasmota)",
     "sortName": "Water Valve:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWater Valve00000047",
     "homebridge": "homebridge",
@@ -937,7 +937,7 @@
   },
   {
     "name": "West Bedroom",
-    "fullName": "West Bedroom - Fan",
+    "fullName": "West Bedroom - Fan (Tasmota)",
     "sortName": "West Bedroom:Fan",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWest Bedroom00000040",
     "homebridge": "homebridge",
@@ -946,7 +946,7 @@
   },
   {
     "name": "West Bedroom",
-    "fullName": "West Bedroom - Lightbulb",
+    "fullName": "West Bedroom - Lightbulb (Tasmota)",
     "sortName": "West Bedroom:Lightbulb",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaWest Bedroom00000043",
     "homebridge": "homebridge",
@@ -955,7 +955,7 @@
   },
   {
     "name": "Xmas Tree",
-    "fullName": "Xmas Tree - Outlet",
+    "fullName": "Xmas Tree - Outlet (Tasmota)",
     "sortName": "Xmas Tree:Outlet",
     "uniqueId": "homebridge1C:22:3D:E3:CF:34TasmotaXmas Tree00000047",
     "homebridge": "homebridge",


### PR DESCRIPTION
Redeploying any node was triggering a full 20s rediscovery that tore down the monitor and flashed all nodes red - even unchanged ones. Fixed by persisting the HapClient at module level across deploys so mDNS discovery doesn't restart, and connecting new nodes immediately from the existing device list when devices are already known. The monitor is finished in `close()` and recreated when new client nodes register, but the underlying HapClient and its discovered instances survive. Nodes already connected to the same device are skipped during `connectClientNodes`, so rediscovery from a single unmatched node no longer disturbs the rest.

Messages sent during startup (e.g. via inject) were silently dropped with "HB not initialized". Now queued with a 30s timeout and drained once connected.

Also fixed: `done()` not called in control/status/resume handlers, `connectClientNodes` not awaited, `sendInitialState` firing on every reconnect, stale devices never removed from `hbDevices`, refresh endpoint being a no-op, missing permission routes for hb-status/hb-control, `oneditsave` crash on empty dropdown, and a few other small things.

The device identifier string (instance name + username + manufacturer + friendly name + uuid prefix) was constructed in 3 separate places with subtle inline differences. Extracted `getDeviceIdentifier()` and `getFriendlyName()` as single source of truth.

The editor refresh button had no visual feedback — now spins while loading, shows `RED.notify` on errors, and guards against double-clicks. The duplicated `oneditprepare`/`oneditsave` code across all 4 node types was extracted into shared functions (~220 lines removed). Route registration in HapDeviceRoutes was similarly collapsed from 12 entries to 3, using `hb-conf.read` as the shared permission since all routes operate on config node data.

`toList()` was ignoring its `{ perms }` argument entirely - `evDevices` and `ctDevices` were identical. Now filters by characteristic permissions so control nodes only show writable devices.

`refreshDeviceList` now uses `Object.assign` to update existing service objects in-place, preserving object references for `===` checks while refreshing all properties including method closures bound to the current HapClient.

Removed unused `better-queue` production dependency. Fixed pre-existing test crash (missing `node.error` mock).

Lint and tests pass.